### PR TITLE
Add a 100ms delay to screenshotting the venue icon

### DIFF
--- a/lib/venues/add-venue/widgets/upload_venue_photo.dart
+++ b/lib/venues/add-venue/widgets/upload_venue_photo.dart
@@ -52,15 +52,15 @@ class _UploadVenuePhotoState extends State<UploadVenuePhoto> {
           locate<VenuesService>()
               .updateLocalVenue(largePhotoPath: _croppedFilePath);
           // convert the VenueIcon widget to a png and upload bytes
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            _screenshotController.capture().then((bytes) {
-              locate<VenuesService>().updateLocalVenue(iconBytes: bytes);
-              if (mounted) {
-                setState(() {
-                  _loading = false;
-                });
-              }
-            });
+          _screenshotController
+              .capture(delay: const Duration(milliseconds: 100))
+              .then((bytes) {
+            locate<VenuesService>().updateLocalVenue(iconBytes: bytes);
+            if (mounted) {
+              setState(() {
+                _loading = false;
+              });
+            }
           });
         }
       }


### PR DESCRIPTION
We need to let the image file get read in and displayed before calling
capture so a longer delay is needed.

Closes #49 (though it is a bit of a hack and might want revisiting)