### PR TITLE
Keep token fresh by storing on resume

### DIFF
--- a/functions/src/follow-request.ts
+++ b/functions/src/follow-request.ts
@@ -1,4 +1,3 @@
-// import {log} from 'firebase-functions/logger';
 import {FieldValue, getFirestore} from 'firebase-admin/firestore';
 import {getMessaging} from 'firebase-admin/messaging';
 import {log} from 'firebase-functions/logger';
@@ -50,6 +49,7 @@ export const followRequest = onCall(
         throw new HttpsError('not-found',
           'Token snapshot.data() was undefined.');
       }
+      log(`Fetched requestee token: ${tokenData?.token}`);
 
       // Fetch the requester's profile
       const profileDoc = await db
@@ -62,6 +62,7 @@ export const followRequest = onCall(
         throw new HttpsError('not-found',
           'Token snapshot.data() was undefined.');
       }
+      log('Fetched the requester\'s profile');
 
       // Send an FCM message to the requestee with requester's name
       const message = {

--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -1,5 +1,7 @@
 import 'package:crowdleague/messages/messages_screen.dart';
 import 'package:crowdleague/notifications/notificatons_screen.dart';
+import 'package:crowdleague/services/messaging_service.dart';
+import 'package:crowdleague/utils/locator.dart';
 import 'package:crowdleague/venues/venues_screen.dart';
 import 'package:crowdleague/you/you_screen.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +15,27 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   int currentPageIndex = 0;
+  late final AppLifecycleListener _lifecycleListener;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize the AppLifecycleListener class and pass a callback that
+    // stores the latest FCM token.
+    _lifecycleListener = AppLifecycleListener(
+      onStateChange: (lifecycleState) async {
+        if (lifecycleState == AppLifecycleState.resumed) {
+          String? token = await locate<MessagingService>().getToken();
+          if (token != null) {
+            locate<MessagingService>().storeToken(token);
+          }
+        }
+        // If the NotificationsScreen is open and there is a new Notification
+        // we want to rebuild the screen.
+        setState(() {});
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -56,5 +79,11 @@ class _HomeScreenState extends State<HomeScreen> {
         const YouScreen(),
       ][currentPageIndex],
     );
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    super.dispose();
   }
 }

--- a/lib/services/messaging_service.dart
+++ b/lib/services/messaging_service.dart
@@ -16,7 +16,7 @@ class MessagingService {
     _messaging.onTokenRefresh.listen((fcmToken) {
       storeToken(fcmToken);
     }).onError((err) {
-      // Error getting token.
+      throw 'Error getting token: $err';
     });
   }
 


### PR DESCRIPTION
Part of #110 
Closes #96 

The strategy for now is to just store the token each time - we 
could keep the token in local storage and check if the FCM 
token is new and only then write but we probably will want to
keep a timestamp anyway so will most likely store on each resume.