### PR TITLE
Add splitting crews functionality

### DIFF
--- a/functions/src/accept-crew-request.ts
+++ b/functions/src/accept-crew-request.ts
@@ -20,13 +20,11 @@ export const acceptCrewRequest = onCall(
         });
       await db.collection('profiles')
         .doc(`${request.data.requesteeId}`).update({
-          crew:
-            FieldValue.arrayUnion(request.data.requesterId),
+          crewIds: FieldValue.arrayUnion(request.data.requesterId),
         });
       await db.collection('profiles')
         .doc(`${request.data.requesterId}`).update({
-          crew:
-            FieldValue.arrayUnion(request.data.requesteeId),
+          crewIds: FieldValue.arrayUnion(request.data.requesteeId),
         });
       log('Removed the pending member and added the crew members');
 
@@ -34,7 +32,7 @@ export const acceptCrewRequest = onCall(
       const requesterTokenSnapshot = await db.collection('fcmTokens')
         .doc(`${request.data.requesterId}`).get();
       const requesteeTokenSnapshot = await db.collection('fcmTokens')
-        .doc(`${request.auth.uid}`).get();
+        .doc(`${request.data.requesteeId}`).get();
       if (!requesterTokenSnapshot.exists || !requesteeTokenSnapshot.exists) {
         throw new HttpsError('not-found', 'Token snapshot did not exist.');
       }
@@ -46,23 +44,19 @@ export const acceptCrewRequest = onCall(
       }
       log('Got the requester\'s and requestee\'s fcm token');
 
-      // Store the requestee's id and fcm token in followers
-      await db.collection('followers').doc(request.auth.uid)
+      // Store the requestee's id and fcm token under followers
+      await db.collection('profiles').doc(request.auth.uid)
         .set({
-          tokensAndIds: FieldValue.arrayUnion(
-            {token: requesterTokenData.token, uid: request.data.requesterId}
-          ),
+          followerTokens: FieldValue.arrayUnion(requesterTokenData.token),
         }, {merge: true});
-      log('Stored the requestee\'s id and fcm token in followers');
+      log('Stored the requestee\'s id and fcm token under followers');
 
-      // Store the requester's id and fcm token in followers
-      await db.collection('followers').doc(request.data.requesterId)
+      // Store the requester's id and fcm token under followers
+      await db.collection('profiles').doc(request.data.requesterId)
         .set({
-          tokensAndIds: FieldValue.arrayUnion(
-            {token: requesteeTokenData.token, uid: request.auth.uid}
-          ),
+          followerTokens: FieldValue.arrayUnion(requesteeTokenData.token),
         }, {merge: true});
-      log('Stored the requester\'s id and fcm token in followers');
+      log('Stored the requester\'s id and fcm token under followers');
 
       // Change the type of the notification to a CrewAcceptedNotification
       await db

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,3 +4,4 @@ admin.initializeApp();
 
 export * from './crew-request';
 export * from './accept-crew-request';
+export * from './split-crews';

--- a/functions/src/split-crews.ts
+++ b/functions/src/split-crews.ts
@@ -1,0 +1,69 @@
+import {FieldValue, getFirestore} from 'firebase-admin/firestore';
+import {log} from 'firebase-functions/logger';
+import {HttpsError, onCall} from 'firebase-functions/v2/https';
+
+export const splitCrews = onCall(
+  {cors: true},
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError('unauthenticated', 'request.auth was undefined.');
+      }
+
+      const db = getFirestore('firestore-usa');
+
+      log(`requesteeId = ${request.data.requesteeId}, ` +
+        `requesterId = ${request.data.requesterId}`);
+
+      // Get the requestee & requester's fcm token
+      const requesterTokenSnapshot = await db.collection('fcmTokens')
+        .doc(`${request.data.requesterId}`).get();
+      const requesteeTokenSnapshot = await db.collection('fcmTokens')
+        .doc(`${request.data.requesteeId}`).get();
+      if (!requesterTokenSnapshot.exists || !requesteeTokenSnapshot.exists) {
+        throw new HttpsError('not-found', 'Token snapshot did not exist.');
+      }
+      const requesterTokenData = requesterTokenSnapshot.data();
+      const requesteeTokenData = requesteeTokenSnapshot.data();
+      if (!requesterTokenData || !requesteeTokenData) {
+        throw new HttpsError('not-found', 'Token snapshot.data() ' +
+          'was undefined.');
+      }
+      log('Got the requester\'s and requestee\'s fcm token');
+
+      // Remove the requester's crew id and fcm token as followers
+      await db.collection('profiles').doc(request.data.requesteeId)
+        .set({
+          crewIds: FieldValue.arrayRemove(request.data.requesterId),
+          followerTokens: FieldValue.arrayRemove(requesterTokenData.token),
+        }, {merge: true});
+      log('Removed the requester\'s crew id and fcm token as followers');
+
+      // Remove the requestee's crew id and fcm token as followers
+      await db.collection('profiles').doc(request.data.requesterId)
+        .set({
+          crewIds: FieldValue.arrayRemove(request.data.requesteeId),
+          followerTokens: FieldValue.arrayRemove(requesteeTokenData.token),
+        }, {merge: true});
+      log('Removed the requestee\'s crew id and fcm token as followers');
+
+      // Add a Notification to requester's Notifications list
+      await db
+        .collection('notifications').doc()
+        .set({
+          playerId: request.data.requesterId,
+          type: 'split-crew',
+          requesteeId: request.data.requesteeId,
+          requesterId: request.data.requesterId,
+          timestamp: FieldValue.serverTimestamp(),
+          opened: false,
+          viewed: false,
+          waiting: false,
+        });
+      log(`CrewSplitNotification added for ${request.data.requesterId}`);
+
+      return true;
+    } catch (e) {
+      throw new HttpsError('unknown', `${e}.`);
+    }
+  });

--- a/lib/notifications/models/notifications.dart
+++ b/lib/notifications/models/notifications.dart
@@ -38,6 +38,16 @@ sealed class Notification {
           requesteeId: json['requesteeId'],
           timestamp: (json['timestamp'] as Timestamp).millisecondsSinceEpoch,
         );
+      case 'split-crew':
+        return SplitCrewsNotification(
+          id: json['id'] ?? '',
+          playerId: json['playerId'] ?? '',
+          viewed: json['viewed'] ?? false,
+          opened: json['opened'] ?? false,
+          requesterId: json['requesterId'],
+          requesteeId: json['requesteeId'],
+          timestamp: (json['timestamp'] as Timestamp).millisecondsSinceEpoch,
+        );
       default:
         throw Exception('Unknown notification type');
     }
@@ -99,6 +109,34 @@ class CrewAcceptedNotification extends Notification {
       'requesterId': requesterId,
       'requesteeId': requesteeId,
       'waiting': waiting,
+      'viewed': viewed,
+      'opened': opened,
+      'timestamp': timestamp,
+    };
+  }
+}
+
+class SplitCrewsNotification extends Notification {
+  final String requesterId;
+  final String requesteeId;
+
+  const SplitCrewsNotification({
+    required this.requesteeId,
+    required this.requesterId,
+    required super.id,
+    required super.playerId,
+    required super.timestamp,
+    required super.opened,
+    required super.viewed,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'playerId': playerId,
+      'type': 'split-crew',
+      'requesterId': requesterId,
+      'requesteeId': requesteeId,
       'viewed': viewed,
       'opened': opened,
       'timestamp': timestamp,

--- a/lib/notifications/notificatons_screen.dart
+++ b/lib/notifications/notificatons_screen.dart
@@ -5,6 +5,7 @@ import '../services/user_service.dart';
 import 'models/notifications.dart';
 import 'widgets/crew_accepted_notification_widget.dart';
 import 'widgets/crew_request_notification_widget.dart';
+import 'widgets/split_crews_notification_widget.dart';
 
 class NotificationsScreen extends StatefulWidget {
   const NotificationsScreen({super.key});
@@ -28,11 +29,13 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                 itemBuilder: (context, index) {
                   final Notification notification =
                       notificatiosnSnapshot.data![index];
+                  // TODO: use a pattern here
                   if (notification is CrewRequestNotification) {
-                    return CrewRequestNotificationWidget(
-                        notification: notification);
+                    return CrewRequestNotificationWidget(notification);
                   } else if (notification is CrewAcceptedNotification) {
                     return CrewAcceptedNotificationWidget(notification);
+                  } else if (notification is SplitCrewsNotification) {
+                    return SplitCrewsNotificationWidget(notification);
                   } else {
                     return Container();
                   }

--- a/lib/notifications/widgets/crew_request_notification_widget.dart
+++ b/lib/notifications/widgets/crew_request_notification_widget.dart
@@ -7,10 +7,7 @@ import '../../utils/locator.dart';
 import '../models/notifications.dart';
 
 class CrewRequestNotificationWidget extends StatefulWidget {
-  const CrewRequestNotificationWidget({
-    required this.notification,
-    super.key,
-  });
+  const CrewRequestNotificationWidget(this.notification, {super.key});
 
   final CrewRequestNotification notification;
 

--- a/lib/notifications/widgets/split_crews_notification_widget.dart
+++ b/lib/notifications/widgets/split_crews_notification_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../services/players_service.dart';
+import '../../utils/async_avatar.dart';
+import '../../utils/locator.dart';
+import '../models/notifications.dart';
+
+class SplitCrewsNotificationWidget extends StatefulWidget {
+  const SplitCrewsNotificationWidget(this.notification, {super.key});
+
+  final SplitCrewsNotification notification;
+
+  @override
+  State<SplitCrewsNotificationWidget> createState() =>
+      _SplitCrewsNotificationWidgetState();
+}
+
+class _SplitCrewsNotificationWidgetState
+    extends State<SplitCrewsNotificationWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future:
+          locate<PlayersService>().getPlayer(widget.notification.requesteeId),
+      builder: (context, playerSnapshot) {
+        if (playerSnapshot.hasData && playerSnapshot.data != null) {
+          final player = playerSnapshot.data!;
+
+          return Card(
+              child: ListTile(
+                  onTap: () {
+                    context.pushNamed('player-profile',
+                        pathParameters: {'id': player.id});
+                  },
+                  leading: AsyncAvatar(
+                      bytesFuture: locate<PlayersService>()
+                          .retrieveSmallProfilePic(player.id)),
+                  title: Text('${player.name}\'s crew was split from yours')));
+        } else {
+          return SizedBox.shrink();
+        }
+      },
+    );
+  }
+}

--- a/lib/onboarding/edit_profile_pic_screen.dart
+++ b/lib/onboarding/edit_profile_pic_screen.dart
@@ -119,7 +119,7 @@ class _EditProfilePicScreenState extends State<EditProfilePicScreen> {
                 if (_uploading) LinearProgressIndicator(),
               ],
             ),
-            const SizedBox(height: 30),
+            const SizedBox(height: 50),
             Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -144,7 +144,7 @@ class _EditProfilePicScreenState extends State<EditProfilePicScreen> {
                           ))
                     ],
                   ),
-                  const SizedBox(height: 20),
+                  const SizedBox(height: 30),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [

--- a/lib/players/models/player.dart
+++ b/lib/players/models/player.dart
@@ -2,13 +2,13 @@ class Player {
   final String id;
   final String name;
   final List<String> pendingCrewRequests;
-  final List<String> crew;
+  final List<String> crewIds;
 
   const Player({
     required this.id,
     required this.name,
     required this.pendingCrewRequests,
-    required this.crew,
+    required this.crewIds,
   });
 
   Map<String, dynamic> toJson() {
@@ -16,7 +16,7 @@ class Player {
       'id': id,
       'name': name,
       'crewRequests': pendingCrewRequests,
-      'crew': crew,
+      'crewIds': crewIds,
     };
   }
 
@@ -27,7 +27,8 @@ class Player {
       pendingCrewRequests: (json['pendingCrewRequests'] == null)
           ? []
           : List<String>.from(json['pendingCrewRequests']),
-      crew: (json['crew'] == null) ? [] : List<String>.from(json['crew']),
+      crewIds:
+          (json['crewIds'] == null) ? [] : List<String>.from(json['crewIds']),
     );
   }
 
@@ -42,6 +43,6 @@ class EmptyPlayer extends Player {
     super.id = '',
     super.name = '?',
     super.pendingCrewRequests = const [],
-    super.crew = const [],
+    super.crewIds = const [],
   });
 }

--- a/lib/players/player_profile_screen.dart
+++ b/lib/players/player_profile_screen.dart
@@ -32,7 +32,8 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
         _player = player ?? EmptyPlayer();
         _pending = _player.pendingCrewRequests
             .contains(locate<UserAuthService>().currentUserId!);
-        _crew = _player.crew.contains(locate<UserAuthService>().currentUserId!);
+        _crew =
+            _player.crewIds.contains(locate<UserAuthService>().currentUserId!);
       });
     }
   }
@@ -43,9 +44,7 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
         _pending = true;
       });
     }
-    await locate<UserService>().requestCrew(
-        requesteeId: widget._playerId,
-        requesterId: locate<UserAuthService>().currentUserId!);
+    await locate<UserService>().requestCrew(playerId: widget._playerId);
   }
 
   @override
@@ -111,9 +110,9 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
                       TextButton(
                         onPressed: _pending ? null : () => _requestCrew(),
                         child:
-                            _pending ? Text('Pending...') : Text('Join Crew'),
+                            _pending ? Text('Pending...') : Text('Join Crews'),
                       ),
-                    if (!_owner && _crew) CrewMenuButton(),
+                    if (!_owner && _crew) CrewMenuButton(playerId: _player.id),
                   ],
                 ),
               ],

--- a/lib/players/widgets/crew_menu_button.dart
+++ b/lib/players/widgets/crew_menu_button.dart
@@ -1,7 +1,11 @@
+import 'package:crowdleague/services/user_service.dart';
+import 'package:crowdleague/utils/locator.dart';
 import 'package:flutter/material.dart';
 
 class CrewMenuButton extends StatefulWidget {
-  const CrewMenuButton({super.key});
+  const CrewMenuButton({required this.playerId, super.key});
+
+  final String playerId;
 
   @override
   State<CrewMenuButton> createState() => _CrewMenuButtonState();
@@ -22,7 +26,9 @@ class _CrewMenuButtonState extends State<CrewMenuButton> {
       childFocusNode: _buttonFocusNode,
       menuChildren: <Widget>[
         MenuItemButton(
-          onPressed: () {},
+          onPressed: () {
+            locate<UserService>().splitCrews(widget.playerId);
+          },
           child: const Text('Split your crews'),
         ),
         MenuItemButton(

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -58,11 +58,11 @@ class UserService {
     });
   }
 
-  Future<void> requestCrew(
-      {required String requesteeId, required String requesterId}) async {
-    await _cloudFunctions
-        .httpsCallable('crewRequest')
-        .call({'requesterId': requesterId, 'requesteeId': requesteeId});
+  Future<void> requestCrew({required String playerId}) async {
+    await _cloudFunctions.httpsCallable('crewRequest').call({
+      'requesterId': _auth.currentUser?.uid,
+      'requesteeId': playerId,
+    });
   }
 
   Future<void> acceptCrewRequest({
@@ -87,6 +87,13 @@ class UserService {
 
     await _firestore.doc('profiles/${_auth.currentUser?.uid}').update({
       'pendingCrewRequests': FieldValue.arrayRemove([requesterId])
+    });
+  }
+
+  Future<void> splitCrews(String playerId) async {
+    await _cloudFunctions.httpsCallable('splitCrews').call({
+      'requesterId': '${_auth.currentUser?.uid}',
+      'requesteeId': playerId,
     });
   }
 }

--- a/lib/you/you_screen.dart
+++ b/lib/you/you_screen.dart
@@ -40,9 +40,12 @@ class _YouScreenState extends State<YouScreen> {
       ),
       body: ListView(
         children: [
+          SizedBox(
+            height: 20,
+          ),
           Card(
             child: ListTile(
-              title: const Text('Grow your crew'),
+              title: const Text('Expand your crew'),
               onTap: () {
                 context.push('/find-players');
               },


### PR DESCRIPTION
We now have 'crewIds' and 'followerTokens' in the 'profiles/{uid}'
document in order to track who is in your crew and who you are
following. Splitting crews removes both.

Closes #122
Closes #124