### PR TITLE
Update buttons locally not on firestore change

### DIFF
--- a/functions/src/crew-request.ts
+++ b/functions/src/crew-request.ts
@@ -72,7 +72,7 @@ export const crewRequest = onCall(
       const message = {
         notification: {
           title: 'Expand your crew?',
-          body: `${profileData?.name} wants to join crews`,
+          body: `${profileData?.name} wants to join your crew`,
         },
         token: tokenData?.token,
       };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -184,6 +184,10 @@ class _CrowdLeagueAppState extends State<CrowdLeagueApp> {
             fontFamily: 'Raleway',
             fontSize: 18,
           ),
+          displaySmall: TextStyle(
+            fontFamily: 'Raleway',
+            fontSize: 14,
+          ),
         ),
       ),
       darkTheme: ThemeData.dark().copyWith(
@@ -199,6 +203,10 @@ class _CrowdLeagueAppState extends State<CrowdLeagueApp> {
           displayMedium: TextStyle(
             fontFamily: 'Raleway',
             fontSize: 18,
+          ),
+          displaySmall: TextStyle(
+            fontFamily: 'Raleway',
+            fontSize: 14,
           ),
         ),
       ),

--- a/lib/players/player_profile_screen.dart
+++ b/lib/players/player_profile_screen.dart
@@ -22,11 +22,19 @@ class PlayerProfileScreen extends StatefulWidget {
 
 class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
   bool _owner = false; // if the profile is the user's profile
+  bool _localPending = false;
 
   @override
   void initState() {
     super.initState();
     _owner = widget._playerId == locate<UserAuthService>().currentUserId!;
+  }
+
+  Future<void> splitCrewsCallback() async {
+    await locate<UserService>().splitCrews(widget._playerId);
+    setState(() {
+      _localPending = false;
+    });
   }
 
   @override
@@ -37,7 +45,7 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
           stream: locate<PlayersService>().listenToPlayer(widget._playerId),
           builder: (context, snapshot) {
             final Player player = snapshot.data ?? EmptyPlayer();
-            final pending = player.pendingCrewRequests
+            final bool pending = player.pendingCrewRequests
                 .contains(locate<UserAuthService>().currentUserId!);
             final crew = player.crewIds
                 .contains(locate<UserAuthService>().currentUserId!);
@@ -93,22 +101,44 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
                         mainAxisAlignment: MainAxisAlignment.start,
                         children: [
                           if (!_owner && !crew)
-                            TextButton(
-                              onPressed: pending
-                                  ? null
-                                  : () => locate<UserService>()
-                                      .requestCrew(playerId: widget._playerId),
-                              child: pending
-                                  ? Text('Pending...')
-                                  : Text('Join Crews'),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 8.0),
+                              child: OutlinedButton(
+                                onPressed: pending || _localPending
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _localPending = true;
+                                        });
+                                        locate<UserService>().requestCrew(
+                                            playerId: widget._playerId);
+                                      },
+                                child: pending || _localPending
+                                    ? Text(
+                                        'Pending...',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .displaySmall!,
+                                      )
+                                    : Text(
+                                        'Join Crew',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .displaySmall!,
+                                      ),
+                              ),
                             ),
                           if (!_owner && crew)
-                            CrewMenuButton(playerId: player.id),
+                            CrewMenuButton(callback: splitCrewsCallback),
                         ],
                       ),
                       Padding(
-                        padding: const EdgeInsets.only(top: 20, bottom: 20),
-                        child: Text('Crew Members'),
+                        padding: const EdgeInsets.only(
+                            left: 8.0, top: 20, bottom: 20),
+                        child: Text(
+                          'Crew Members',
+                          style: Theme.of(context).textTheme.displaySmall!,
+                        ),
                       ),
                       SizedBox(
                         height: 60,

--- a/lib/players/widgets/crew_menu_button.dart
+++ b/lib/players/widgets/crew_menu_button.dart
@@ -1,11 +1,9 @@
-import 'package:crowdleague/services/user_service.dart';
-import 'package:crowdleague/utils/locator.dart';
 import 'package:flutter/material.dart';
 
 class CrewMenuButton extends StatefulWidget {
-  const CrewMenuButton({required this.playerId, super.key});
+  const CrewMenuButton({required this.callback, super.key});
 
-  final String playerId;
+  final Function callback;
 
   @override
   State<CrewMenuButton> createState() => _CrewMenuButtonState();
@@ -27,17 +25,23 @@ class _CrewMenuButtonState extends State<CrewMenuButton> {
       menuChildren: <Widget>[
         MenuItemButton(
           onPressed: () {
-            locate<UserService>().splitCrews(widget.playerId);
+            widget.callback();
           },
-          child: const Text('Split your crews'),
+          child: Text(
+            'Split your crews',
+            style: Theme.of(context).textTheme.displaySmall!,
+          ),
         ),
         MenuItemButton(
           onPressed: () {},
-          child: const Text('Unfollow'),
+          child: Text(
+            'Unfollow',
+            style: Theme.of(context).textTheme.displaySmall!,
+          ),
         ),
       ],
       builder: (_, MenuController controller, Widget? child) {
-        return TextButton(
+        return TextButton.icon(
           focusNode: _buttonFocusNode,
           onPressed: () {
             if (controller.isOpen) {
@@ -46,7 +50,11 @@ class _CrewMenuButtonState extends State<CrewMenuButton> {
               controller.open();
             }
           },
-          child: Text('Part of your crew'),
+          icon: Icon(Icons.arrow_drop_down),
+          label: Text(
+            'Part of your crew',
+            style: Theme.of(context).textTheme.displaySmall!,
+          ),
         );
       },
     );


### PR DESCRIPTION
In player profile we were waiting for the cloud function to update the
firestore, leaving the UI stuck temporarily. Now we update the UI
immediately and let the  firestore change change it back.

Closes #148 