### PR TITLE
Add a prototypeItem to predetermine item extents

### DIFF
--- a/lib/notifications/notificatons_screen.dart
+++ b/lib/notifications/notificatons_screen.dart
@@ -25,6 +25,10 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
           builder: (context, notificatiosnSnapshot) {
             if (notificatiosnSnapshot.hasData) {
               return ListView.builder(
+                prototypeItem: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: 80),
+                  child: Container(),
+                ),
                 itemCount: notificatiosnSnapshot.data!.length,
                 itemBuilder: (context, index) {
                   final Notification notification =


### PR DESCRIPTION
Closes #153

But creates a different problem, tracked in #159.