### PR TITLE
Fix infinite loading spinner on profile photo upload

### DIFF
--- a/lib/onboarding/edit_profile_pic_screen.dart
+++ b/lib/onboarding/edit_profile_pic_screen.dart
@@ -31,6 +31,7 @@ class _EditProfilePicScreenState extends State<EditProfilePicScreen> {
       setState(() {
         _uploading = true;
       });
+
       XFile? pickedFile = await locate<ImagesService>().pickImage(source);
       if (pickedFile == null) {
         if (mounted) {
@@ -38,34 +39,48 @@ class _EditProfilePicScreenState extends State<EditProfilePicScreen> {
             _uploading = false;
           });
         }
-      } else {
-        final croppedFilePath =
-            await locate<ImagesService>().cropImage(pickedFile);
-        if (croppedFilePath == null) {
-          if (mounted) {
-            setState(() {
-              _uploading = false;
-            });
-          }
-        } else {
-          if (mounted) {
-            setState(() {
-              _croppedFilePath = croppedFilePath;
-            });
-          }
-          await locate<ImagesService>().saveProfilePic(_croppedFilePath!);
+        return;
+      }
 
-          // navigate based on whether we are onboarding or not
-          if (mounted && _onboarding) {
-            context.push('/onboard-notifications');
-          } else if (mounted && !_onboarding) {
-            context.pop();
-          }
+      final croppedFilePath =
+          await locate<ImagesService>().cropImage(pickedFile);
+      if (croppedFilePath == null) {
+        if (mounted) {
+          setState(() {
+            _uploading = false;
+          });
+        }
+        return;
+      }
+
+      if (mounted) {
+        setState(() {
+          _croppedFilePath = croppedFilePath;
+        });
+      }
+
+      await locate<ImagesService>().saveProfilePic(_croppedFilePath!);
+
+      if (mounted) {
+        setState(() {
+          _uploading = false;
+        });
+        // navigate based on whether we are onboarding or not
+        if (_onboarding) {
+          context.push('/onboard-notifications');
+        } else {
+          context.pop();
         }
       }
     } catch (e) {
+      log('Error uploading profile pic: $e');
       if (mounted) {
-        log(e.toString());
+        setState(() {
+          _uploading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to upload photo. Please try again.')),
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- Reset `_uploading = false` after successful upload before navigation
- Reset `_uploading = false` in catch block to stop spinner on error
- Show SnackBar error message when upload fails
- Simplify control flow with early returns

## Root Cause
The `_uploading` state was never reset to `false`:
- After successful upload, code navigated away without resetting state
- In catch block, error was logged but state wasn't reset

## Test plan
- [ ] Select photo from gallery → loading spinner stops after upload
- [ ] Cancel photo selection → loading spinner stops
- [ ] Simulate upload failure → SnackBar error shown, spinner stops

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)