### PR TITLE
Add flutter platforms config for Crashlytics symbol upload

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,5 +12,29 @@
       "firebase-debug.*.log",
       "*.local"
     ]
+  },
+  "flutter": {
+    "platforms": {
+      "ios": {
+        "default": {
+          "projectId": "crowdleague-project",
+          "appId": "1:945991608888:ios:e86c73c1fd8b65cc6314cd",
+          "uploadDebugSymbols": true
+        }
+      },
+      "macos": {
+        "default": {
+          "projectId": "crowdleague-project",
+          "appId": "1:945991608888:ios:19a70067619dec436314cd",
+          "uploadDebugSymbols": true
+        }
+      },
+      "android": {
+        "default": {
+          "projectId": "crowdleague-project",
+          "appId": "1:945991608888:android:1a93eb485d7157716314cd"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Add `flutter.platforms` section to `firebase.json` with iOS, macOS, and Android configuration.

## Problem
iOS build was failing during the FlutterFire Crashlytics symbol upload phase:
```
Unhandled exception:
type 'Null' is not a subtype of type 'Map<dynamic, dynamic>' in type cast
#0      appleConfigFromFirebaseJson
```

## Solution
Added the required `flutter.platforms` configuration with:
- iOS: projectId, appId, uploadDebugSymbols
- macOS: projectId, appId, uploadDebugSymbols  
- Android: projectId, appId

## Test plan
- [ ] Run `flutter run -d <ios-device>` - build should succeed
- [ ] Crashlytics symbol upload phase completes without error

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)