### PR TITLE
Fix onboarding notifications text formatting

### DIFF
--- a/lib/onboarding/onboard_notifications.dart
+++ b/lib/onboarding/onboard_notifications.dart
@@ -43,9 +43,12 @@ class _OnboardNotificationsState extends State<OnboardNotifications> {
                     style: Theme.of(context).textTheme.headlineMedium,
                   ),
                   const SizedBox(height: 16),
-                  const Text(
-                    'When players you follow want to have a run\nwe will send you a notification',
-                    textAlign: TextAlign.center,
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 32),
+                    child: Text(
+                      'When players you follow want to have a run, we will send you a notification.',
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                   const SizedBox(height: 50),
                   TextButton(


### PR DESCRIPTION
## Summary
- Remove hard-coded `\n` line break from notification description text
- Let text flow naturally based on screen width
- Add horizontal padding (32px) for better readability on all screen sizes
- Fix punctuation

## Before
```
When players you follow want to have a run
we will send you a notification
```
(Hard line break causes awkward wrapping on different screen sizes)

## After
```
When players you follow want to have a run, we will send you a notification.
```
(Text flows naturally with proper padding)

## Test plan
- [ ] View onboarding notifications screen on narrow device
- [ ] View on wide device/tablet
- [ ] Text should wrap naturally without awkward breaks

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)