### PR TITLE
Add 3 UI quick wins: app name, auto-fill name, sign-out confirmation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     
     <application
-        android:label="crowdleague"
+        android:label="CrowdLeague"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/lib/onboarding/edit_name_screen.dart
+++ b/lib/onboarding/edit_name_screen.dart
@@ -22,7 +22,9 @@ class _EditNameScreenState extends State<EditNameScreen> {
   Future<void> _getCurrentName() async {
     final player = await locate<PlayersService>()
         .retrievePlayer(locate<UserService>().currentUserId!);
-    _textController.text = player?.name ?? '';
+    // Use existing name, or fall back to auth display name (from Google/Apple)
+    _textController.text =
+        player?.name ?? locate<UserService>().authDisplayName ?? '';
     _textController.selection = TextSelection(
       baseOffset: 0,
       extentOffset: _textController.text.length,

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -57,6 +57,10 @@ class UserService {
 
   String? get currentUserId => _auth.currentUser?.uid;
 
+  /// Returns the display name from the auth provider (Google/Apple).
+  /// Useful for pre-filling the name field during onboarding.
+  String? get authDisplayName => _auth.currentUser?.displayName;
+
   Stream<Map<String, Object?>?> get profileDocStream => _userSubject.stream;
 
   Future<void> signInWithGoogle() async {

--- a/lib/you/you_screen.dart
+++ b/lib/you/you_screen.dart
@@ -66,6 +66,33 @@ class _YouScreenState extends State<YouScreen> {
     }
   }
 
+  Future<void> _showSignOutConfirmation() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Sign Out?'),
+        content: const Text('Are you sure you want to sign out?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Sign Out'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await locate<UserService>().signOut();
+      if (mounted) {
+        context.replace('/signin');
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -107,10 +134,7 @@ class _YouScreenState extends State<YouScreen> {
           Card(
             child: ListTile(
               title: const Text('Sign Out'),
-              onTap: () {
-                locate<UserService>().signOut();
-                context.replace('/signin');
-              },
+              onTap: _showSignOutConfirmation,
             ),
           ),
           const SizedBox(height: 40),

--- a/test/user_feedback_bugs_test.dart
+++ b/test/user_feedback_bugs_test.dart
@@ -396,7 +396,7 @@ void main() {
         // Collect emitted values
         final emittedCounts = <int>[];
         final subscription = mockConversationsService.numUnreadMessagesStream
-            .listen((count) => emittedCounts.add(count));
+            .listen((value) => emittedCounts.add(value));
 
         // Emit unread counts
         mockConversationsService.setUnreadCount(5);
@@ -573,6 +573,9 @@ class MockUserService implements UserService {
   // Stub remaining UserService methods
   @override
   String? get currentUserId => 'test-user-id';
+
+  @override
+  String? get authDisplayName => 'Test User';
 
   @override
   Stream<Map<String, Object?>?> get profileDocStream => Stream.value({});


### PR DESCRIPTION
## Summary
- Fix Android app name capitalization to "CrowdLeague" (#215)
- Auto-fill name field from Google/Apple auth during onboarding (#217)
- Add confirmation dialog before signing out (#225)

## Test plan
- [ ] Verify Android app displays "CrowdLeague" in launcher/recents
- [ ] Sign in with Google, verify name field pre-populated during onboarding
- [ ] Tap Sign Out, verify confirmation dialog appears
- [ ] Cancel sign out, verify user stays signed in
- [ ] Confirm sign out, verify redirect to sign-in screen

Closes #215, closes #217, closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)