### PR TITLE
Add build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,11 @@ migrate_working_dir/
 .pub/
 /build/
 /coverage/
+functions/coverage/
 ios/build/
+
+# Firebase
+.firebase/
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
## Summary
- Add `.firebase/` (Firebase CLI cache)
- Add `functions/coverage/` (test coverage output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)