### PR TITLE
Add 3 more UI quick wins: branding, empty states, clarity

### DIFF
--- a/lib/auth/sign_in_screen.dart
+++ b/lib/auth/sign_in_screen.dart
@@ -48,6 +48,26 @@ class _SignInScreenState extends State<SignInScreen> {
             : Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
+                  Icon(
+                    Icons.sports_basketball,
+                    size: 80,
+                    color: Theme.of(context).primaryColor,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'CrowdLeague',
+                    style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Find players. Join the game.',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                  const SizedBox(height: 48),
                   if (!kIsWeb &&
                       (defaultTargetPlatform == TargetPlatform.iOS ||
                           defaultTargetPlatform == TargetPlatform.macOS))

--- a/lib/conversations/conversations_screen.dart
+++ b/lib/conversations/conversations_screen.dart
@@ -21,7 +21,10 @@ class _ConversationsScreenState extends State<ConversationsScreen> {
           future:
               locate<ConversationsService>().retrieveConversationViewModels(),
           builder: (context, snapshot) {
-            if (snapshot.hasData) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (snapshot.hasData && snapshot.data!.isNotEmpty) {
               final List<ConversationViewModel> conversationViewModels =
                   snapshot.data!;
               return ListView.builder(
@@ -31,7 +34,32 @@ class _ConversationsScreenState extends State<ConversationsScreen> {
                         conversationViewModel: conversationViewModels[index]);
                   });
             } else {
-              return Container();
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.chat_bubble_outline,
+                      size: 64,
+                      color: Colors.grey[400],
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No messages yet',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Start a conversation from a player profile',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey[500],
+                          ),
+                    ),
+                  ],
+                ),
+              );
             }
           }),
     );

--- a/lib/players/find_players_screen.dart
+++ b/lib/players/find_players_screen.dart
@@ -21,12 +21,22 @@ class _FindPlayersScreenState extends State<FindPlayersScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(
+        title: const Text('Find Players'),
+      ),
       body: Column(
         children: [
-          TextField(
-            controller: _nameTextController,
-            autofocus: true,
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: TextField(
+              controller: _nameTextController,
+              autofocus: true,
+              decoration: const InputDecoration(
+                hintText: 'Search by name',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+            ),
           ),
           FutureBuilder<List<Player>>(
               future: locate<PlayersService>().retrievePlayers(),

--- a/lib/you/you_screen.dart
+++ b/lib/you/you_screen.dart
@@ -136,7 +136,8 @@ class _YouScreenState extends State<YouScreen> {
           Card(
             child: ListTile(
               leading: const Icon(Icons.group_add),
-              title: const Text('Expand your crew'),
+              title: const Text('Find Players'),
+              subtitle: const Text('Connect with players to build your crew'),
               onTap: () {
                 context.push('/find-players');
               },


### PR DESCRIPTION
## Summary
- Add app branding (icon, title, tagline) to sign-in screen (#216)
- Add empty state with icon and guidance to conversations screen (#223)
- Rename "Expand your crew" to "Find Players" with subtitle (#227)
- Add title and search styling to Find Players screen (#227)

## Test plan
- [ ] Sign-in screen shows CrowdLeague branding with icon and tagline
- [ ] Conversations screen shows "No messages yet" when empty
- [ ] You screen shows "Find Players" with subtitle
- [ ] Find Players screen has title and styled search field

Closes #216, closes #223, closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)