### PR TITLE
Add onboarding tutorial overlay for first-time users (#219)

### DIFF
--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -2,12 +2,15 @@ import 'package:crowdleague/conversations/conversations_screen.dart';
 import 'package:crowdleague/conversations/conversations_service.dart';
 import 'package:crowdleague/notifications/notificatons_screen.dart';
 import 'package:crowdleague/services/messaging_service.dart';
+import 'package:crowdleague/services/tutorial_notifier.dart';
 import 'package:crowdleague/notifications/notifications_service.dart';
 import 'package:crowdleague/utils/locator.dart';
 import 'package:crowdleague/venues/venues_screen.dart';
 import 'package:crowdleague/you/you_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
 import 'enums/navigation_destinations.dart';
 
@@ -21,6 +24,13 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   int _currentPageIndex = 0;
   late final AppLifecycleListener _lifecycleListener;
+
+  // Tutorial keys for targeting UI elements
+  final GlobalKey _venuesTabKey = GlobalKey();
+  final GlobalKey _notificationsTabKey = GlobalKey();
+  final GlobalKey _messagesTabKey = GlobalKey();
+  final GlobalKey _youTabKey = GlobalKey();
+  final GlobalKey _fabKey = GlobalKey();
 
   @override
   void initState() {
@@ -48,6 +58,184 @@ class _HomeScreenState extends State<HomeScreen> {
         }
       },
     );
+
+    // Show tutorial on first launch after onboarding
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final prefs = await SharedPreferences.getInstance();
+      final tutorialShown = prefs.getBool('tutorialShown') ?? false;
+      if (!tutorialShown && mounted) {
+        _showTutorial();
+        await prefs.setBool('tutorialShown', true);
+      } else {
+        // Tutorial already shown, enable location immediately
+        locate<TutorialNotifier>().markComplete();
+      }
+    });
+  }
+
+  void _showTutorial() {
+    final targets = <TargetFocus>[
+      TargetFocus(
+        identify: 'venues',
+        keyTarget: _venuesTabKey,
+        alignSkip: Alignment.topRight,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Venues',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  'Find local sports venues on the map',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'fab',
+        keyTarget: _fabKey,
+        alignSkip: Alignment.topRight,
+        contents: [
+          TargetContent(
+            align: ContentAlign.bottom,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Add Venue',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  'Tap here to add new venues you discover',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'notifications',
+        keyTarget: _notificationsTabKey,
+        alignSkip: Alignment.topRight,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Notifications',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  'Get notified when players want to play',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'messages',
+        keyTarget: _messagesTabKey,
+        alignSkip: Alignment.topRight,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Messages',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  'Chat with other players',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'you',
+        keyTarget: _youTabKey,
+        alignSkip: Alignment.topRight,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Your Profile',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                SizedBox(height: 10),
+                Text(
+                  'Manage your profile and crews',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ];
+
+    TutorialCoachMark(
+      targets: targets,
+      colorShadow: Colors.black,
+      textSkip: 'SKIP',
+      paddingFocus: 10,
+      opacityShadow: 0.8,
+      onFinish: () {
+        locate<TutorialNotifier>().markComplete();
+      },
+      onSkip: () {
+        locate<TutorialNotifier>().markComplete();
+        return true;
+      },
+    ).show(context: context);
   }
 
   @override
@@ -67,57 +255,69 @@ class _HomeScreenState extends State<HomeScreen> {
         backgroundColor: Colors.grey.shade200,
         selectedIndex: _currentPageIndex,
         destinations: <Widget>[
-          NavigationDestination(
-            selectedIcon: Icon(Icons.map),
-            icon: Icon(Icons.map_outlined),
-            label: NavigationDestinations.venues.description,
+          KeyedSubtree(
+            key: _venuesTabKey,
+            child: NavigationDestination(
+              selectedIcon: Icon(Icons.map),
+              icon: Icon(Icons.map_outlined),
+              label: NavigationDestinations.venues.description,
+            ),
           ),
-          StreamBuilder<int>(
-              stream:
-                  locate<NotificationsService>().numNotificationsViewedStream,
-              builder: (context, snapshot) {
-                int numNotifications = snapshot.data ?? 0;
-                return (numNotifications == 0)
-                    ? NavigationDestination(
-                        selectedIcon: Icon(Icons.notifications_on_sharp),
-                        icon: Icon(Icons.notifications_none_outlined),
-                        label: NavigationDestinations.notifications.description,
-                      )
-                    : NavigationDestination(
-                        selectedIcon: Badge(
-                            label: Text(numNotifications.toString()),
-                            child: Icon(Icons.notifications_on_sharp)),
-                        icon: Badge(
-                            label: Text(numNotifications.toString()),
-                            child: Icon(Icons.notifications_none_outlined)),
-                        label: 'Notifications',
-                      );
-              }),
-          StreamBuilder<int>(
-              stream:
-                  locate<ConversationsService>().numUnreadMessagesStream,
-              builder: (context, snapshot) {
-                int numUnread = snapshot.data ?? 0;
-                return (numUnread == 0)
-                    ? NavigationDestination(
-                        selectedIcon: Icon(Icons.message),
-                        icon: Icon(Icons.message_outlined),
-                        label: NavigationDestinations.messages.description,
-                      )
-                    : NavigationDestination(
-                        selectedIcon: Badge(
-                            label: Text(numUnread.toString()),
-                            child: Icon(Icons.message)),
-                        icon: Badge(
-                            label: Text(numUnread.toString()),
-                            child: Icon(Icons.message_outlined)),
-                        label: NavigationDestinations.messages.description,
-                      );
-              }),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.person),
-            icon: Icon(Icons.person_2_outlined),
-            label: NavigationDestinations.you.description,
+          KeyedSubtree(
+            key: _notificationsTabKey,
+            child: StreamBuilder<int>(
+                stream:
+                    locate<NotificationsService>().numNotificationsViewedStream,
+                builder: (context, snapshot) {
+                  int numNotifications = snapshot.data ?? 0;
+                  return (numNotifications == 0)
+                      ? NavigationDestination(
+                          selectedIcon: Icon(Icons.notifications_on_sharp),
+                          icon: Icon(Icons.notifications_none_outlined),
+                          label:
+                              NavigationDestinations.notifications.description,
+                        )
+                      : NavigationDestination(
+                          selectedIcon: Badge(
+                              label: Text(numNotifications.toString()),
+                              child: Icon(Icons.notifications_on_sharp)),
+                          icon: Badge(
+                              label: Text(numNotifications.toString()),
+                              child: Icon(Icons.notifications_none_outlined)),
+                          label: 'Notifications',
+                        );
+                }),
+          ),
+          KeyedSubtree(
+            key: _messagesTabKey,
+            child: StreamBuilder<int>(
+                stream: locate<ConversationsService>().numUnreadMessagesStream,
+                builder: (context, snapshot) {
+                  int numUnread = snapshot.data ?? 0;
+                  return (numUnread == 0)
+                      ? NavigationDestination(
+                          selectedIcon: Icon(Icons.message),
+                          icon: Icon(Icons.message_outlined),
+                          label: NavigationDestinations.messages.description,
+                        )
+                      : NavigationDestination(
+                          selectedIcon: Badge(
+                              label: Text(numUnread.toString()),
+                              child: Icon(Icons.message)),
+                          icon: Badge(
+                              label: Text(numUnread.toString()),
+                              child: Icon(Icons.message_outlined)),
+                          label: NavigationDestinations.messages.description,
+                        );
+                }),
+          ),
+          KeyedSubtree(
+            key: _youTabKey,
+            child: NavigationDestination(
+              selectedIcon: Icon(Icons.person),
+              icon: Icon(Icons.person_2_outlined),
+              label: NavigationDestinations.you.description,
+            ),
           ),
         ],
       ),
@@ -130,6 +330,7 @@ class _HomeScreenState extends State<HomeScreen> {
       floatingActionButton:
           _currentPageIndex == NavigationDestinations.venues.index
               ? FloatingActionButton(
+                  key: _fabKey,
                   onPressed: () {
                     context.push('/select-new-venue-location');
                   },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'players/player_profile_screen.dart';
 import 'services/geo_location_service.dart';
 import 'services/images_service.dart';
 import 'services/messaging_service.dart';
+import 'services/tutorial_notifier.dart';
 import 'notifications/notifications_service.dart';
 import 'players/players_service.dart';
 import 'services/user_service.dart';
@@ -177,6 +178,7 @@ void main() async {
     storage: storage,
     firebaseAuth: auth,
   ));
+  Locator.add<TutorialNotifier>(TutorialNotifier());
 
   runApp(const CrowdLeagueApp());
 }

--- a/lib/services/tutorial_notifier.dart
+++ b/lib/services/tutorial_notifier.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart';
+
+/// Notifies listeners when the onboarding tutorial has completed.
+/// Used to delay location permission requests until after the tutorial.
+class TutorialNotifier extends ValueNotifier<bool> {
+  TutorialNotifier() : super(false);
+
+  void markComplete() {
+    value = true;
+  }
+}

--- a/lib/venues/venues_screen.dart
+++ b/lib/venues/venues_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:crowdleague/services/tutorial_notifier.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:crowdleague/venues/venues_service.dart';
@@ -29,6 +30,7 @@ class _VenuesScreenState extends State<VenuesScreen> {
 
   LatLng? _currentLocation;
   final Set<Marker> _markers = {};
+  bool _myLocationEnabled = false;
 
   Future _loadMapStyles() async {
     final styleString =
@@ -89,11 +91,33 @@ class _VenuesScreenState extends State<VenuesScreen> {
     }
   }
 
+  void _onTutorialComplete() {
+    if (mounted) {
+      setState(() {
+        _myLocationEnabled = true;
+      });
+    }
+  }
+
   @override
   void initState() {
     super.initState();
     _loadMapStyles();
     _displayVenues();
+
+    // Enable location after tutorial completes (to avoid permission popup during tutorial)
+    final tutorialNotifier = locate<TutorialNotifier>();
+    if (tutorialNotifier.value) {
+      _myLocationEnabled = true;
+    } else {
+      tutorialNotifier.addListener(_onTutorialComplete);
+    }
+  }
+
+  @override
+  void dispose() {
+    locate<TutorialNotifier>().removeListener(_onTutorialComplete);
+    super.dispose();
   }
 
   @override
@@ -107,7 +131,7 @@ class _VenuesScreenState extends State<VenuesScreen> {
           ? _darkMapStyle
           : null,
       markers: _markers,
-      myLocationEnabled: true,
+      myLocationEnabled: _myLocationEnabled,
       initialCameraPosition: (_currentLocation == null)
           ? VenuesScreen._kMelbourne
           : CameraPosition(target: _currentLocation!),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1132,6 +1132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  tutorial_coach_mark:
+    dependency: "direct main"
+    description:
+      name: tutorial_coach_mark
+      sha256: "5a325d53bcf16ce7a969e2ab8d4dc9610f39ee3eab2b3cc57d5c98936129b891"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   firebase_analytics: ^12.0.0
   cloud_functions: ^6.0.0
   shared_preferences: ^2.3.5
+  tutorial_coach_mark: ^1.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Adds coach mark tutorial overlay using `tutorial_coach_mark` package
- Highlights key UI features: Venues tab, Add Venue FAB, Notifications, Messages, and Profile tabs
- Tutorial shows only once (tracked via SharedPreferences)
- Location permission is deferred until tutorial completes to avoid interrupting the flow

## Test plan
- [ ] Fresh install or clear app data
- [ ] Complete onboarding flow (name, photo, notifications)
- [ ] Verify tutorial overlay appears highlighting each nav tab
- [ ] Verify location permission appears after tutorial finishes (not during)
- [ ] Verify tutorial doesn't appear on subsequent launches

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)