### PR TITLE
Add if-no-files-found: ignore to coverage artifact uploads (#232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: flutter-coverage
           path: coverage/lcov.info
+          if-no-files-found: ignore
 
   functions:
     name: Functions Lint & Test
@@ -90,6 +91,7 @@ jobs:
         with:
           name: functions-coverage
           path: functions/coverage/lcov.info
+          if-no-files-found: ignore
 
   # Summary job for branch protection (replaces old "Analyze & Test" job)
   ci-status:


### PR DESCRIPTION
## Summary
- Add `if-no-files-found: ignore` to Flutter coverage artifact upload
- Add `if-no-files-found: ignore` to Functions coverage artifact upload

## Problem
If tests fail before generating coverage files, or if coverage is disabled, the artifact upload step fails the CI workflow unnecessarily.

## Solution
Configure `upload-artifact@v4` to ignore missing files instead of failing.

## Test plan
- [ ] CI workflow completes successfully with this change
- [ ] If coverage files exist, they are still uploaded as artifacts

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)