### PR TITLE
Add Crews concept explanation to onboarding tutorial (#226)

### DIFF
--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -203,7 +203,7 @@ class _HomeScreenState extends State<HomeScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Your Profile',
+                  'Your Profile & Crew',
                   style: TextStyle(
                     fontWeight: FontWeight.bold,
                     color: Colors.white,
@@ -212,7 +212,14 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'Manage your profile and crews',
+                  'Your "Crew" is your group of sports contacts.',
+                  style: TextStyle(color: Colors.white),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'Find players and tap "Join Crew" to connect. '
+                  'Once they accept, you can message each other '
+                  'and coordinate playing together.',
                   style: TextStyle(color: Colors.white),
                 ),
               ],


### PR DESCRIPTION
## Summary
- Expand "Your Profile" tutorial step to explain what "Crews" are
- Rename title to "Your Profile & Crew"
- Add clear explanation of the Crews concept

## Problem
New users don't understand what "Crews" means - the concept was mentioned but never explained.

## Solution
Update the final onboarding tutorial step to include:
1. "Your 'Crew' is your group of sports contacts."
2. "Find players and tap 'Join Crew' to connect. Once they accept, you can message each other and coordinate playing together."

## Test plan
- [ ] Fresh install shows updated tutorial text on the "You" tab step
- [ ] Tutorial still completes normally and enables location permissions

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)