### PR TITLE
Add info card explaining how to build a crew (#228)

### DIFF
--- a/lib/you/you_screen.dart
+++ b/lib/you/you_screen.dart
@@ -134,10 +134,32 @@ class _YouScreenState extends State<YouScreen> {
             ),
           ),
           Card(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline,
+                      color: Theme.of(context).colorScheme.onPrimaryContainer),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'To build your crew: Find a player, tap "Join Crew", '
+                      'and wait for them to accept.',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Card(
             child: ListTile(
               leading: const Icon(Icons.group_add),
               title: const Text('Find Players'),
-              subtitle: const Text('Connect with players to build your crew'),
+              subtitle: const Text('Search and connect with other players'),
               onTap: () {
                 context.push('/find-players');
               },


### PR DESCRIPTION
## Summary
- Add info card on You screen explaining how to build a crew
- Update "Find Players" subtitle to be clearer

## Problem
Users don't understand how to create their own crew - there's no explicit "create crew" action.

## Solution
Add a prominent info card that explains the process:
> "To build your crew: Find a player, tap 'Join Crew', and wait for them to accept."

Uses `primaryContainer` color scheme for visual distinction.

## Test plan
- [ ] Info card appears on You screen above "Find Players"
- [ ] Text is readable in both light and dark modes
- [ ] Tapping "Find Players" still navigates correctly

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)