### PR TITLE
Fix deployment jobs being skipped on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
     name: Build Android & Deploy to Play Store
     runs-on: ubuntu-latest
     needs: ci-status
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.ci-status.result != 'failure' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Checkout code
@@ -167,7 +167,7 @@ jobs:
     name: Build iOS & Deploy to TestFlight
     runs-on: macos-latest
     needs: ci-status
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.ci-status.result != 'failure' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Deployment jobs were being skipped because `dorny/paths-filter` doesn't detect changes on tag pushes, causing the CI jobs to skip, which then caused deployment jobs to skip due to their dependency chain.

## Fix
Added `always() && needs.ci-status.result != 'failure'` to deployment job conditions so they run on tag pushes even when CI jobs are skipped.

🤖 Generated with [Claude Code](https://claude.ai/code)