### PR TITLE
Add FlutterFire CLI installation to iOS deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Install FlutterFire CLI
+        run: |
+          dart pub global activate flutterfire_cli
+          echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
+
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Fixes flutterfire command not found during Crashlytics dSYM upload.