### PR TITLE
Bump version to 0.0.7+21

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: crowdleague
 description: "Be in a league of your own..."
-publish_to: 'none'
+publish_to: "none"
 
-version: 0.0.5+20
+version: 0.0.7+21
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Version bump for release v0.0.7

This release includes:
- #261: Add error handling for sign-in network errors
- #271: Externalize pitch-deck content to config file
- #274: Add Stripe payment system with webhook support