### PR TITLE
Fix Android build: add ProGuard rules for Stripe

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,6 +52,9 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.release
+            minifyEnabled = true
+            shrinkResources = true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Flutter Stripe - ignore missing push provisioning classes
+# These are React Native classes that aren't used in Flutter
+-dontwarn com.stripe.android.pushProvisioning.**
+-dontwarn com.reactnativestripesdk.**


### PR DESCRIPTION
## Problem

The Android release build fails with R8 missing class errors:

```
Missing class com.stripe.android.pushProvisioning.PushProvisioningActivity$g
Missing class com.stripe.android.pushProvisioning.PushProvisioningActivityStarter$Args
...
```

## Cause

The `flutter_stripe` package includes React Native SDK code that references push provisioning classes not available in the standard Stripe Android SDK.

## Solution

Add ProGuard rules to ignore these missing classes:

```
-dontwarn com.stripe.android.pushProvisioning.**
-dontwarn com.reactnativestripesdk.**
```

Also enables minification and resource shrinking for smaller APK size.

## Testing

This should fix the v0.0.7 Android build failure.