### PR TITLE
Bump version to 0.0.8+22

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: crowdleague
 description: "Be in a league of your own..."
 publish_to: "none"
 
-version: 0.0.7+21
+version: 0.0.8+22
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Version bump for release v0.0.8

Includes fix for Android Stripe ProGuard issue from #277.