### PR TITLE
Bump version to 0.0.9+23

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: crowdleague
 description: "Be in a league of your own..."
 publish_to: "none"
 
-version: 0.0.8+22
+version: 0.0.9+23
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Version bump for release v0.0.9

Includes fix for App Store icon alpha channel (#279).