### PR TITLE
Fix Android Stripe init and Google Maps in release mode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,3 +62,7 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation 'com.google.android.material:material:1.12.0'
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -2,3 +2,9 @@
 # These are React Native classes that aren't used in Flutter
 -dontwarn com.stripe.android.pushProvisioning.**
 -dontwarn com.reactnativestripesdk.**
+
+# Google Maps
+-keep class com.google.android.gms.maps.** { *; }
+-keep class com.google.android.gms.common.** { *; }
+-keep class com.google.maps.** { *; }
+-dontwarn com.google.android.gms.**

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
Fixes two Android issues:

1. **Stripe initialization failure** - The flutter_stripe plugin requires a MaterialComponents theme. Updated `NormalTheme` to use `Theme.MaterialComponents.Light.NoActionBar` (and `DayNight.NoActionBar` for night mode).

2. **Google Maps blank in release mode** - Added ProGuard keep rules to prevent R8 from stripping Google Maps classes during minification.

## Changes
- `android/app/src/main/res/values/styles.xml` - Update NormalTheme parent
- `android/app/src/main/res/values-night/styles.xml` - Update NormalTheme parent  
- `android/app/build.gradle` - Add Material Components dependency
- `android/app/proguard-rules.pro` - Add Google Maps keep rules