### PR TITLE
Bump version to 0.0.10+24 for release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: crowdleague
 description: "Be in a league of your own..."
 publish_to: "none"
 
-version: 0.0.9+23
+version: 0.0.10+24
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Version bump for release v0.0.10

Includes Android fixes from PR #283:
- Fix Stripe initialization (MaterialComponents theme)
- Fix Google Maps in release mode (ProGuard rules)