### PR TITLE
Add loading states to notification buttons and use StreamBuilder

### DIFF
--- a/lib/notifications/notificatons_screen.dart
+++ b/lib/notifications/notificatons_screen.dart
@@ -19,16 +19,16 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Padding(
-        padding: EdgeInsets.all(8.0),
-        child: FutureBuilder(
-          future: locate<NotificationsService>().retrieveNotifications(),
+        padding: const EdgeInsets.all(8.0),
+        child: StreamBuilder<List<NotificationViewModel>>(
+          stream: locate<NotificationsService>().notificationsStream(),
           builder: (context, viewModelsSnapshot) {
             if (viewModelsSnapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
 
             if (viewModelsSnapshot.hasError) {
-              return Center(
+              return const Center(
                 child: Text('Error loading notifications'),
               );
             }

--- a/lib/notifications/widgets/crew_request_notification_widget.dart
+++ b/lib/notifications/widgets/crew_request_notification_widget.dart
@@ -6,7 +6,7 @@ import '../../services/user_service.dart';
 import '../../utils/locator.dart';
 import '../models/views/notification_view_model.dart';
 
-class CrewRequestNotificationWidget extends StatelessWidget {
+class CrewRequestNotificationWidget extends StatefulWidget {
   const CrewRequestNotificationWidget(
     CrewRequestNotificationViewModel viewModel, {
     super.key,
@@ -14,24 +14,48 @@ class CrewRequestNotificationWidget extends StatelessWidget {
 
   final CrewRequestNotificationViewModel _notificationViewModel;
 
-  Future<void> _declineCrewRequest(
-      String notificationId, String requesterId) async {
-    locate<UserService>().declineCrewRequest(
-      notificationId,
-      requesterId,
+  @override
+  State<CrewRequestNotificationWidget> createState() =>
+      _CrewRequestNotificationWidgetState();
+}
+
+class _CrewRequestNotificationWidgetState
+    extends State<CrewRequestNotificationWidget> {
+  bool _isAccepting = false;
+  bool _isDeclining = false;
+
+  Future<void> _acceptCrewRequest() async {
+    setState(() => _isAccepting = true);
+    await locate<UserService>().acceptCrewRequest(
+      requesterId: widget._notificationViewModel.requesterId,
+      requesteeId: widget._notificationViewModel.requesteeId,
+      notificationId: widget._notificationViewModel.notification.id,
+    );
+  }
+
+  Future<void> _declineCrewRequest() async {
+    setState(() => _isDeclining = true);
+    await locate<UserService>().declineCrewRequest(
+      widget._notificationViewModel.notification.id,
+      widget._notificationViewModel.requesterId,
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = _isAccepting || _isDeclining;
+    final showWaiting = widget._notificationViewModel.waiting || _isAccepting;
+
     return Card(
       color: Theme.of(context).brightness == Brightness.dark
           ? Colors.grey.shade800
           : Colors.white,
       child: ListTile(
-        leading: Avatar(playerId: _notificationViewModel.requesterId, picSize: PicSize.small),
+        leading: Avatar(
+            playerId: widget._notificationViewModel.requesterId,
+            picSize: PicSize.small),
         title: Text(
-          '${_notificationViewModel.requesterName} wants to join crews',
+          '${widget._notificationViewModel.requesterName} wants to join crews',
           style: Theme.of(context).textTheme.bodyLarge!,
           overflow: TextOverflow.ellipsis,
           maxLines: 2,
@@ -40,32 +64,47 @@ class CrewRequestNotificationWidget extends StatelessWidget {
           spacing: 10,
           runSpacing: 8,
           children: [
-            if (!_notificationViewModel.waiting) ...[
+            if (!showWaiting && !_isDeclining) ...[
               OutlinedButton(
-                onPressed: () {
-                  locate<UserService>().acceptCrewRequest(
-                    requesterId: _notificationViewModel.requesterId,
-                    requesteeId: _notificationViewModel.requesteeId,
-                    notificationId: _notificationViewModel.notification.id,
-                  );
-                },
+                onPressed: isLoading ? null : _acceptCrewRequest,
                 child: Text(
                   'Accept',
                   style: Theme.of(context).textTheme.bodyMedium!,
                 ),
               ),
               OutlinedButton(
-                onPressed: () {
-                  _declineCrewRequest(_notificationViewModel.notification.id,
-                      _notificationViewModel.requesterId);
-                },
+                onPressed: isLoading ? null : _declineCrewRequest,
                 child: Text(
                   'Decline',
                   style: Theme.of(context).textTheme.bodyMedium!,
                 ),
               ),
-            ] else
-              Text('Updating crew members...'),
+            ] else if (_isDeclining)
+              const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  SizedBox(width: 8),
+                  Text('Declining...'),
+                ],
+              )
+            else
+              const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  SizedBox(width: 8),
+                  Text('Updating crew members...'),
+                ],
+              ),
           ],
         ),
       ),

--- a/test/user_feedback_bugs_test.dart
+++ b/test/user_feedback_bugs_test.dart
@@ -185,7 +185,8 @@ void main() {
 
         // Tap Accept button
         await tester.tap(find.widgetWithText(OutlinedButton, 'Accept'));
-        await tester.pumpAndSettle();
+        // Use pump() instead of pumpAndSettle() because CircularProgressIndicator never settles
+        await tester.pump();
 
         // Verify service was called with correct arguments
         expect(mockUserService.acceptCrewRequestCalled, isTrue,
@@ -248,7 +249,8 @@ void main() {
 
         // Tap Decline button
         await tester.tap(find.widgetWithText(OutlinedButton, 'Decline'));
-        await tester.pumpAndSettle();
+        // Use pump() instead of pumpAndSettle() because CircularProgressIndicator never settles
+        await tester.pump();
 
         // Verify service was called with correct arguments
         expect(mockUserService.declineCrewRequestCalled, isTrue,
@@ -303,7 +305,8 @@ void main() {
             ),
           ),
         );
-        await tester.pumpAndSettle();
+        // Use pump() instead of pumpAndSettle() because CircularProgressIndicator never settles
+        await tester.pump();
 
         // Buttons should not be visible when waiting
         expect(find.text('Accept'), findsNothing,


### PR DESCRIPTION
## Summary

Improves the notifications screen UX by showing loading states when buttons are pressed and updating in real-time.

## Problem

1. When tapping Accept/Decline on a crew request notification, there was no visual feedback that the action was in progress
2. After an action completed, users had to leave the notifications tab and come back to see the updated state

## Solution

### CrewRequestNotificationWidget
- Converted from StatelessWidget to StatefulWidget
- Added `_isAccepting` and `_isDeclining` state variables
- Show a loading spinner with "Updating crew members..." or "Declining..." text when action is in progress
- Disable both buttons during loading to prevent double-taps

### NotificationsScreen
- Changed from `FutureBuilder` to `StreamBuilder`
- Now uses `notificationsStream()` which listens for real-time updates
- Notifications automatically update when Firestore data changes

## Testing

- Verified loading indicator appears when Accept is pressed
- Verified loading indicator appears when Decline is pressed
- Verified notification disappears after decline completes
- Verified notification updates after accept completes