### PR TITLE
Fix crew menu text contrast in dark mode

### DIFF
--- a/lib/players/widgets/crew_menu_button.dart
+++ b/lib/players/widgets/crew_menu_button.dart
@@ -29,14 +29,14 @@ class _CrewMenuButtonState extends State<CrewMenuButton> {
           },
           child: Text(
             'Split your crews',
-            style: Theme.of(context).textTheme.displaySmall!,
+            style: Theme.of(context).textTheme.bodyLarge,
           ),
         ),
         MenuItemButton(
           onPressed: () {},
           child: Text(
             'Unfollow',
-            style: Theme.of(context).textTheme.displaySmall!,
+            style: Theme.of(context).textTheme.bodyLarge,
           ),
         ),
       ],


### PR DESCRIPTION
## Summary

Fixes poor text contrast in the crew dropdown menu when using dark mode.

## Problem

The 'Split your crews' and 'Unfollow' menu items were using `displaySmall` text style which has a light/pink color that doesn't contrast well against the menu's light background in dark mode.

## Solution

Changed the menu item text style from `displaySmall` to `bodyLarge`, which uses the appropriate text color for menu items and ensures readable contrast.

## Before
White/pink text on light pink background - hard to read

## After
Dark text on light background - proper contrast