### PR TITLE
Bump version to 0.0.12+26 for release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: crowdleague
 description: "Be in a league of your own..."
 publish_to: "none"
 
-version: 0.0.11+25
+version: 0.0.12+26
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
## Release v0.0.12

Bumps version for release with venue-based crews feature.

### Changes in this release
- Venue-based crews (Phase 1) - players can now join/leave venue crews
- Removed old peer-to-peer crew system
- Simplified notification handling

### After merge
Tag with `v0.0.12` to trigger store deployments.