### PR TITLE
Add Teams feature (Phase 2A - Basic Teams)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -54,6 +54,26 @@ service cloud.firestore {
       allow create: if false;
     }
 
+    // ==================== TEAMS ====================
+    // All authenticated users can read teams (for viewing team profiles)
+    // Team mutations go through Cloud Functions (which use Admin SDK)
+    match /teams/{teamId} {
+      allow read: if isAuthenticated();
+      // All write operations go through Cloud Functions
+      allow create, update, delete: if false;
+    }
+
+    // ==================== TEAM INVITES ====================
+    // Users can only read invites they sent or received
+    // All write operations go through Cloud Functions
+    match /teamInvites/{inviteId} {
+      allow read: if isAuthenticated()
+        && (resource.data.inviterId == request.auth.uid
+            || resource.data.inviteeId == request.auth.uid);
+      // All write operations go through Cloud Functions
+      allow create, update, delete: if false;
+    }
+
     // ==================== CONVERSATIONS ====================
     // Users can only access conversations they are a participant in
     match /conversations/{conversationId} {

--- a/functions/src/accept-team-invite.ts
+++ b/functions/src/accept-team-invite.ts
@@ -1,0 +1,102 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+const MAX_ROSTER_SIZE = 15;
+
+export const acceptTeamInvite = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const inviteId = request.data.inviteId;
+      const dbName = request.data.dbName;
+
+      if (!inviteId) {
+        throw new HttpsError("invalid-argument", "inviteId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get and validate invite
+      const inviteDoc = await db.collection("teamInvites").doc(inviteId).get();
+      if (!inviteDoc.exists) {
+        throw new HttpsError("not-found", "Invite not found.");
+      }
+      const inviteData = inviteDoc.data()!;
+
+      if (inviteData.inviteeId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "This invite is not for you.",
+        );
+      }
+      if (inviteData.status !== "pending") {
+        throw new HttpsError(
+          "failed-precondition",
+          "Invite has already been processed.",
+        );
+      }
+
+      // Check team still exists and has room
+      const teamDoc = await db.collection("teams").doc(inviteData.teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team no longer exists.");
+      }
+      const teamData = teamDoc.data()!;
+
+      if (teamData.memberIds && teamData.memberIds.length >= MAX_ROSTER_SIZE) {
+        throw new HttpsError("failed-precondition", "Team roster is now full.");
+      }
+
+      log(
+        `User ${userId} accepting invite ${inviteId} ` +
+          `to team ${inviteData.teamId}`,
+      );
+
+      const batch = db.batch();
+
+      // Update invite status
+      batch.update(inviteDoc.ref, { status: "accepted" });
+
+      // Add user to team
+      batch.update(teamDoc.ref, {
+        memberIds: FieldValue.arrayUnion(userId),
+      });
+
+      // Add team to user's profile
+      batch.update(db.collection("profiles").doc(userId), {
+        teamIds: FieldValue.arrayUnion(inviteData.teamId),
+      });
+
+      // Notify captain that invite was accepted
+      const notificationRef = db.collection("notifications").doc();
+      batch.set(notificationRef, {
+        type: "team-invite-accepted",
+        playerId: inviteData.inviterId,
+        teamId: inviteData.teamId,
+        teamName: inviteData.teamName,
+        inviteeId: userId,
+        viewed: false,
+        opened: false,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      await batch.commit();
+
+      log(`User ${userId} successfully joined team ${inviteData.teamId}`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in acceptTeamInvite: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/create-team.ts
+++ b/functions/src/create-team.ts
@@ -1,0 +1,54 @@
+import {FieldValue, getFirestore} from 'firebase-admin/firestore';
+import {log} from 'firebase-functions/logger';
+import {HttpsError, onCall} from 'firebase-functions/v2/https';
+
+export const createTeam = onCall(
+  {
+    cors: true,
+    region: 'us-central1',
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError('unauthenticated', 'User must be authenticated.');
+      }
+
+      const userId = request.auth.uid;
+      const teamName = request.data.teamName;
+      const dbName = request.data.dbName;
+
+      if (!teamName || teamName.trim().length === 0) {
+        throw new HttpsError('invalid-argument', 'Team name is required.');
+      }
+
+      const db = getFirestore(dbName);
+
+      log(`User ${userId} creating team: ${teamName}`);
+
+      const batch = db.batch();
+
+      // Create team document with creator as captain and first member
+      const teamRef = db.collection('teams').doc();
+      batch.set(teamRef, {
+        name: teamName.trim(),
+        captainId: userId,
+        memberIds: [userId],
+        createdAt: FieldValue.serverTimestamp(),
+      });
+
+      // Add team to user's teamIds
+      const profileRef = db.collection('profiles').doc(userId);
+      batch.update(profileRef, {
+        teamIds: FieldValue.arrayUnion(teamRef.id),
+      });
+
+      await batch.commit();
+
+      log(`Team ${teamRef.id} created successfully`);
+
+      return {success: true, teamId: teamRef.id};
+    } catch (e) {
+      log(`Error in createTeam: ${e}`);
+      throw new HttpsError('aborted', `${e}`);
+    }
+  });

--- a/functions/src/decline-team-invite.ts
+++ b/functions/src/decline-team-invite.ts
@@ -1,0 +1,76 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+export const declineTeamInvite = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const inviteId = request.data.inviteId;
+      const dbName = request.data.dbName;
+
+      if (!inviteId) {
+        throw new HttpsError("invalid-argument", "inviteId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get and validate invite
+      const inviteDoc = await db.collection("teamInvites").doc(inviteId).get();
+      if (!inviteDoc.exists) {
+        throw new HttpsError("not-found", "Invite not found.");
+      }
+      const inviteData = inviteDoc.data()!;
+
+      if (inviteData.inviteeId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "This invite is not for you.",
+        );
+      }
+      if (inviteData.status !== "pending") {
+        throw new HttpsError(
+          "failed-precondition",
+          "Invite has already been processed.",
+        );
+      }
+
+      log(`User ${userId} declining invite ${inviteId}`);
+
+      const batch = db.batch();
+
+      // Update invite status
+      batch.update(inviteDoc.ref, { status: "declined" });
+
+      // Optionally notify captain (low priority)
+      const notificationRef = db.collection("notifications").doc();
+      batch.set(notificationRef, {
+        type: "team-invite-declined",
+        playerId: inviteData.inviterId,
+        teamId: inviteData.teamId,
+        teamName: inviteData.teamName,
+        inviteeId: userId,
+        viewed: false,
+        opened: false,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      await batch.commit();
+
+      log(`Invite ${inviteId} declined`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in declineTeamInvite: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/delete-team.ts
+++ b/functions/src/delete-team.ts
@@ -1,0 +1,92 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+export const deleteTeam = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const teamId = request.data.teamId;
+      const dbName = request.data.dbName;
+
+      if (!teamId) {
+        throw new HttpsError("invalid-argument", "teamId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get team
+      const teamDoc = await db.collection("teams").doc(teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team not found.");
+      }
+      const teamData = teamDoc.data()!;
+
+      // Only captain can delete
+      if (teamData.captainId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "Only the captain can delete the team.",
+        );
+      }
+
+      log(`Captain ${userId} deleting team ${teamId}`);
+
+      const batch = db.batch();
+
+      // Remove team from all members' profiles
+      const memberIds = teamData.memberIds || [];
+      for (const memberId of memberIds) {
+        const profileRef = db.collection("profiles").doc(memberId);
+        batch.update(profileRef, {
+          teamIds: FieldValue.arrayRemove(teamId),
+        });
+
+        // Notify members (except captain) that team was deleted
+        if (memberId !== userId) {
+          const notificationRef = db.collection("notifications").doc();
+          batch.set(notificationRef, {
+            type: "team-deleted",
+            playerId: memberId,
+            teamId: teamId,
+            teamName: teamData.name,
+            viewed: false,
+            opened: false,
+            timestamp: FieldValue.serverTimestamp(),
+          });
+        }
+      }
+
+      // Delete all pending invites for this team
+      const pendingInvites = await db
+        .collection("teamInvites")
+        .where("teamId", "==", teamId)
+        .where("status", "==", "pending")
+        .get();
+
+      for (const invite of pendingInvites.docs) {
+        batch.delete(invite.ref);
+      }
+
+      // Delete the team
+      batch.delete(teamDoc.ref);
+
+      await batch.commit();
+
+      log(`Team ${teamId} deleted successfully`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in deleteTeam: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,3 +9,13 @@ export * from "./resize-images";
 export * from "./delete-account";
 export * from "./create-payment-intent";
 export * from "./stripe-webhook";
+
+// Team functions
+export * from "./create-team";
+export * from "./invite-to-team";
+export * from "./accept-team-invite";
+export * from "./decline-team-invite";
+export * from "./leave-team";
+export * from "./remove-from-team";
+export * from "./transfer-captaincy";
+export * from "./delete-team";

--- a/functions/src/invite-to-team.ts
+++ b/functions/src/invite-to-team.ts
@@ -1,0 +1,116 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+const MAX_ROSTER_SIZE = 15;
+
+export const inviteToTeam = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const teamId = request.data.teamId;
+      const inviteeId = request.data.inviteeId;
+      const dbName = request.data.dbName;
+
+      if (!teamId) {
+        throw new HttpsError("invalid-argument", "teamId is required.");
+      }
+      if (!inviteeId) {
+        throw new HttpsError("invalid-argument", "inviteeId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Verify user is captain
+      const teamDoc = await db.collection("teams").doc(teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team not found.");
+      }
+      const teamData = teamDoc.data()!;
+
+      if (teamData.captainId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "Only the captain can invite players.",
+        );
+      }
+
+      // Check roster limit
+      if (teamData.memberIds && teamData.memberIds.length >= MAX_ROSTER_SIZE) {
+        throw new HttpsError(
+          "failed-precondition",
+          `Team roster is full (${MAX_ROSTER_SIZE} max).`,
+        );
+      }
+
+      // Check if player is already on team
+      if (teamData.memberIds && teamData.memberIds.includes(inviteeId)) {
+        throw new HttpsError(
+          "already-exists",
+          "Player is already on the team.",
+        );
+      }
+
+      // Check for existing pending invite
+      const existingInvite = await db
+        .collection("teamInvites")
+        .where("teamId", "==", teamId)
+        .where("inviteeId", "==", inviteeId)
+        .where("status", "==", "pending")
+        .get();
+
+      if (!existingInvite.empty) {
+        throw new HttpsError(
+          "already-exists",
+          "An invite is already pending for this player.",
+        );
+      }
+
+      log(`Captain ${userId} inviting ${inviteeId} to team ${teamId}`);
+
+      const batch = db.batch();
+
+      // Create team invite
+      const inviteRef = db.collection("teamInvites").doc();
+      batch.set(inviteRef, {
+        teamId: teamId,
+        teamName: teamData.name,
+        inviterId: userId,
+        inviteeId: inviteeId,
+        status: "pending",
+        createdAt: FieldValue.serverTimestamp(),
+      });
+
+      // Create notification for invitee
+      const notificationRef = db.collection("notifications").doc();
+      batch.set(notificationRef, {
+        type: "team-invite",
+        playerId: inviteeId,
+        teamId: teamId,
+        teamName: teamData.name,
+        inviterId: userId,
+        inviteId: inviteRef.id,
+        viewed: false,
+        opened: false,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      await batch.commit();
+
+      log(`Invite ${inviteRef.id} created successfully`);
+
+      return { success: true, inviteId: inviteRef.id };
+    } catch (e) {
+      log(`Error in inviteToTeam: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/leave-team.ts
+++ b/functions/src/leave-team.ts
@@ -1,0 +1,73 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+export const leaveTeam = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const teamId = request.data.teamId;
+      const dbName = request.data.dbName;
+
+      if (!teamId) {
+        throw new HttpsError("invalid-argument", "teamId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get team
+      const teamDoc = await db.collection("teams").doc(teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team not found.");
+      }
+      const teamData = teamDoc.data()!;
+
+      // Captain cannot leave - must delete team or transfer captaincy first
+      if (teamData.captainId === userId) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Captain cannot leave. Delete the team or transfer captaincy first.",
+        );
+      }
+
+      // Check user is a member
+      if (!teamData.memberIds || !teamData.memberIds.includes(userId)) {
+        throw new HttpsError(
+          "failed-precondition",
+          "You are not a member of this team.",
+        );
+      }
+
+      log(`User ${userId} leaving team ${teamId}`);
+
+      const batch = db.batch();
+
+      // Remove user from team
+      batch.update(teamDoc.ref, {
+        memberIds: FieldValue.arrayRemove(userId),
+      });
+
+      // Remove team from user's profile
+      batch.update(db.collection("profiles").doc(userId), {
+        teamIds: FieldValue.arrayRemove(teamId),
+      });
+
+      await batch.commit();
+
+      log(`User ${userId} successfully left team ${teamId}`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in leaveTeam: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/remove-from-team.ts
+++ b/functions/src/remove-from-team.ts
@@ -1,0 +1,97 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+export const removeFromTeam = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const teamId = request.data.teamId;
+      const playerId = request.data.playerId;
+      const dbName = request.data.dbName;
+
+      if (!teamId) {
+        throw new HttpsError("invalid-argument", "teamId is required.");
+      }
+      if (!playerId) {
+        throw new HttpsError("invalid-argument", "playerId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get team
+      const teamDoc = await db.collection("teams").doc(teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team not found.");
+      }
+      const teamData = teamDoc.data()!;
+
+      // Only captain can remove members
+      if (teamData.captainId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "Only the captain can remove members.",
+        );
+      }
+
+      // Cannot remove yourself (captain) - use deleteTeam instead
+      if (playerId === userId) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Captain cannot remove themselves. Transfer captaincy first.",
+        );
+      }
+
+      // Check player is a member
+      if (!teamData.memberIds || !teamData.memberIds.includes(playerId)) {
+        throw new HttpsError(
+          "failed-precondition",
+          "Player is not a member of this team.",
+        );
+      }
+
+      log(`Captain ${userId} removing ${playerId} from team ${teamId}`);
+
+      const batch = db.batch();
+
+      // Remove player from team
+      batch.update(teamDoc.ref, {
+        memberIds: FieldValue.arrayRemove(playerId),
+      });
+
+      // Remove team from player's profile
+      batch.update(db.collection("profiles").doc(playerId), {
+        teamIds: FieldValue.arrayRemove(teamId),
+      });
+
+      // Notify removed player
+      const notificationRef = db.collection("notifications").doc();
+      batch.set(notificationRef, {
+        type: "team-removed",
+        playerId: playerId,
+        teamId: teamId,
+        teamName: teamData.name,
+        viewed: false,
+        opened: false,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      await batch.commit();
+
+      log(`Player ${playerId} removed from team ${teamId}`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in removeFromTeam: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/functions/src/transfer-captaincy.ts
+++ b/functions/src/transfer-captaincy.ts
@@ -1,0 +1,96 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { log } from "firebase-functions/logger";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+
+export const transferCaptaincy = onCall(
+  {
+    cors: true,
+    region: "us-central1",
+  },
+  async (request) => {
+    try {
+      if (!request.auth) {
+        throw new HttpsError("unauthenticated", "User must be authenticated.");
+      }
+
+      const userId = request.auth.uid;
+      const teamId = request.data.teamId;
+      const newCaptainId = request.data.newCaptainId;
+      const dbName = request.data.dbName;
+
+      if (!teamId) {
+        throw new HttpsError("invalid-argument", "teamId is required.");
+      }
+      if (!newCaptainId) {
+        throw new HttpsError("invalid-argument", "newCaptainId is required.");
+      }
+
+      const db = getFirestore(dbName);
+
+      // Get team
+      const teamDoc = await db.collection("teams").doc(teamId).get();
+      if (!teamDoc.exists) {
+        throw new HttpsError("not-found", "Team not found.");
+      }
+      const teamData = teamDoc.data()!;
+
+      // Only current captain can transfer
+      if (teamData.captainId !== userId) {
+        throw new HttpsError(
+          "permission-denied",
+          "Only the captain can transfer captaincy.",
+        );
+      }
+
+      // Cannot transfer to yourself
+      if (newCaptainId === userId) {
+        throw new HttpsError(
+          "invalid-argument",
+          "You are already the captain.",
+        );
+      }
+
+      // New captain must be a team member
+      if (!teamData.memberIds || !teamData.memberIds.includes(newCaptainId)) {
+        throw new HttpsError(
+          "failed-precondition",
+          "New captain must be a team member.",
+        );
+      }
+
+      log(
+        `Captain ${userId} transferring captaincy ` +
+          `to ${newCaptainId} for team ${teamId}`,
+      );
+
+      const batch = db.batch();
+
+      // Update team captain
+      batch.update(teamDoc.ref, {
+        captainId: newCaptainId,
+      });
+
+      // Notify new captain
+      const notificationRef = db.collection("notifications").doc();
+      batch.set(notificationRef, {
+        type: "team-captaincy-received",
+        playerId: newCaptainId,
+        teamId: teamId,
+        teamName: teamData.name,
+        previousCaptainId: userId,
+        viewed: false,
+        opened: false,
+        timestamp: FieldValue.serverTimestamp(),
+      });
+
+      await batch.commit();
+
+      log(`Captaincy transferred to ${newCaptainId} for team ${teamId}`);
+
+      return { success: true };
+    } catch (e) {
+      log(`Error in transferCaptaincy: ${e}`);
+      throw new HttpsError("aborted", `${e}`);
+    }
+  },
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,11 @@ import 'players/players_service.dart';
 import 'services/user_service.dart';
 import 'utils/globals.dart';
 import 'services/payment_service.dart';
+import 'teams/teams_service.dart';
+import 'teams/screens/teams_list_screen.dart';
+import 'teams/screens/create_team_screen.dart';
+import 'teams/screens/team_detail_screen.dart';
+import 'teams/screens/invite_to_team_screen.dart';
 import 'venues/venues_service.dart';
 import 'venues/add-venue/screens/finalise_new_venue_screen.dart';
 import 'venues/add-venue/screens/select_new_venue_location_screen.dart';
@@ -121,6 +126,30 @@ final _router = GoRouter(
         conversationId: state.pathParameters['id']!,
       ),
     ),
+    GoRoute(
+      name: 'teams',
+      path: '/teams',
+      builder: (context, state) => const TeamsListScreen(),
+    ),
+    GoRoute(
+      name: 'create-team',
+      path: '/create-team',
+      builder: (context, state) => const CreateTeamScreen(),
+    ),
+    GoRoute(
+      name: 'team-detail',
+      path: '/team/:id',
+      builder: (context, state) => TeamDetailScreen(
+        teamId: state.pathParameters['id']!,
+      ),
+    ),
+    GoRoute(
+      name: 'invite-to-team',
+      path: '/team/:id/invite',
+      builder: (context, state) => InviteToTeamScreen(
+        teamId: state.pathParameters['id']!,
+      ),
+    ),
   ],
 );
 
@@ -194,6 +223,11 @@ void main() async {
   ));
   Locator.add<TutorialNotifier>(TutorialNotifier());
   Locator.add<PaymentService>(PaymentService(cloudFunctions));
+  Locator.add<TeamsService>(TeamsService(
+    firestore: firestore,
+    auth: auth,
+    cloudFunctions: cloudFunctions,
+  ));
 
   runApp(const CrowdLeagueApp());
 }

--- a/lib/notifications/models/notification.dart
+++ b/lib/notifications/models/notification.dart
@@ -34,6 +34,51 @@ sealed class Notification {
           timestamp: json['timestamp'],
           type: json['type'],
         );
+      // Team notification types
+      case 'team-invite':
+        return TeamInviteNotification(
+          id: json['id'] ?? '',
+          playerId: json['playerId'] ?? '',
+          viewed: json['viewed'] ?? false,
+          opened: json['opened'] ?? false,
+          timestamp: json['timestamp'],
+          teamId: json['teamId'] ?? '',
+          teamName: json['teamName'] ?? '',
+          inviterId: json['inviterId'] ?? '',
+          inviteId: json['inviteId'] ?? '',
+        );
+      case 'team-invite-accepted':
+        return TeamInviteAcceptedNotification(
+          id: json['id'] ?? '',
+          playerId: json['playerId'] ?? '',
+          viewed: json['viewed'] ?? false,
+          opened: json['opened'] ?? false,
+          timestamp: json['timestamp'],
+          teamId: json['teamId'] ?? '',
+          teamName: json['teamName'] ?? '',
+          inviteeId: json['inviteeId'] ?? '',
+        );
+      case 'team-removed':
+        return TeamRemovedNotification(
+          id: json['id'] ?? '',
+          playerId: json['playerId'] ?? '',
+          viewed: json['viewed'] ?? false,
+          opened: json['opened'] ?? false,
+          timestamp: json['timestamp'],
+          teamId: json['teamId'] ?? '',
+          teamName: json['teamName'] ?? '',
+        );
+      case 'team-captaincy-received':
+        return TeamCaptaincyReceivedNotification(
+          id: json['id'] ?? '',
+          playerId: json['playerId'] ?? '',
+          viewed: json['viewed'] ?? false,
+          opened: json['opened'] ?? false,
+          timestamp: json['timestamp'],
+          teamId: json['teamId'] ?? '',
+          teamName: json['teamName'] ?? '',
+          previousCaptainId: json['previousCaptainId'] ?? '',
+        );
       default:
         return UnknownNotification(
           id: json['id'] ?? '',
@@ -68,6 +113,138 @@ class UnknownNotification extends Notification {
       'id': id,
       'playerId': playerId,
       'type': type,
+      'viewed': viewed,
+      'opened': opened,
+      'timestamp': timestamp,
+    };
+  }
+}
+
+/// Team invite notification - sent when a captain invites a player
+class TeamInviteNotification extends Notification {
+  final String teamId;
+  final String teamName;
+  final String inviterId;
+  final String inviteId;
+
+  const TeamInviteNotification({
+    required this.teamId,
+    required this.teamName,
+    required this.inviterId,
+    required this.inviteId,
+    required super.id,
+    required super.playerId,
+    required super.timestamp,
+    required super.opened,
+    required super.viewed,
+  });
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'playerId': playerId,
+      'type': 'team-invite',
+      'teamId': teamId,
+      'teamName': teamName,
+      'inviterId': inviterId,
+      'inviteId': inviteId,
+      'viewed': viewed,
+      'opened': opened,
+      'timestamp': timestamp,
+    };
+  }
+}
+
+/// Notification sent to captain when an invite is accepted
+class TeamInviteAcceptedNotification extends Notification {
+  final String teamId;
+  final String teamName;
+  final String inviteeId;
+
+  const TeamInviteAcceptedNotification({
+    required this.teamId,
+    required this.teamName,
+    required this.inviteeId,
+    required super.id,
+    required super.playerId,
+    required super.timestamp,
+    required super.opened,
+    required super.viewed,
+  });
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'playerId': playerId,
+      'type': 'team-invite-accepted',
+      'teamId': teamId,
+      'teamName': teamName,
+      'inviteeId': inviteeId,
+      'viewed': viewed,
+      'opened': opened,
+      'timestamp': timestamp,
+    };
+  }
+}
+
+/// Notification sent when a player is removed from a team
+class TeamRemovedNotification extends Notification {
+  final String teamId;
+  final String teamName;
+
+  const TeamRemovedNotification({
+    required this.teamId,
+    required this.teamName,
+    required super.id,
+    required super.playerId,
+    required super.timestamp,
+    required super.opened,
+    required super.viewed,
+  });
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'playerId': playerId,
+      'type': 'team-removed',
+      'teamId': teamId,
+      'teamName': teamName,
+      'viewed': viewed,
+      'opened': opened,
+      'timestamp': timestamp,
+    };
+  }
+}
+
+/// Notification sent when captaincy is transferred to a player
+class TeamCaptaincyReceivedNotification extends Notification {
+  final String teamId;
+  final String teamName;
+  final String previousCaptainId;
+
+  const TeamCaptaincyReceivedNotification({
+    required this.teamId,
+    required this.teamName,
+    required this.previousCaptainId,
+    required super.id,
+    required super.playerId,
+    required super.timestamp,
+    required super.opened,
+    required super.viewed,
+  });
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'playerId': playerId,
+      'type': 'team-captaincy-received',
+      'teamId': teamId,
+      'teamName': teamName,
+      'previousCaptainId': previousCaptainId,
       'viewed': viewed,
       'opened': opened,
       'timestamp': timestamp,

--- a/lib/notifications/models/views/notification_view_model.dart
+++ b/lib/notifications/models/views/notification_view_model.dart
@@ -17,3 +17,52 @@ class UnknownNotificationViewModel extends NotificationViewModel {
 
   final String type;
 }
+
+/// View model for team invite notification
+class TeamInviteNotificationViewModel extends NotificationViewModel {
+  const TeamInviteNotificationViewModel({
+    required TeamInviteNotification super.notification,
+    required this.inviterName,
+  });
+
+  final String inviterName;
+
+  TeamInviteNotification get teamInvite =>
+      notification as TeamInviteNotification;
+}
+
+/// View model for team invite accepted notification
+class TeamInviteAcceptedNotificationViewModel extends NotificationViewModel {
+  const TeamInviteAcceptedNotificationViewModel({
+    required TeamInviteAcceptedNotification super.notification,
+    required this.inviteeName,
+  });
+
+  final String inviteeName;
+
+  TeamInviteAcceptedNotification get teamInviteAccepted =>
+      notification as TeamInviteAcceptedNotification;
+}
+
+/// View model for team removed notification
+class TeamRemovedNotificationViewModel extends NotificationViewModel {
+  const TeamRemovedNotificationViewModel({
+    required TeamRemovedNotification super.notification,
+  });
+
+  TeamRemovedNotification get teamRemoved =>
+      notification as TeamRemovedNotification;
+}
+
+/// View model for team captaincy received notification
+class TeamCaptaincyReceivedNotificationViewModel extends NotificationViewModel {
+  const TeamCaptaincyReceivedNotificationViewModel({
+    required TeamCaptaincyReceivedNotification super.notification,
+    required this.previousCaptainName,
+  });
+
+  final String previousCaptainName;
+
+  TeamCaptaincyReceivedNotification get captaincyReceived =>
+      notification as TeamCaptaincyReceivedNotification;
+}

--- a/lib/notifications/notifications_service.dart
+++ b/lib/notifications/notifications_service.dart
@@ -39,7 +39,7 @@ class NotificationsService {
       try {
         final notification =
             Notification.fromJsonWithId(docSnapshot.id, docSnapshot.data());
-        viewModels.add(_convertToViewModel(notification));
+        viewModels.add(await _convertToViewModel(notification));
       } catch (e) {
         // Skip notifications with unknown types or parsing errors
         debugPrint('Error parsing notification ${docSnapshot.id}: $e');
@@ -61,7 +61,7 @@ class NotificationsService {
         try {
           final notification =
               Notification.fromJsonWithId(docSnapshot.id, docSnapshot.data());
-          viewModels.add(_convertToViewModel(notification));
+          viewModels.add(await _convertToViewModel(notification));
         } catch (e) {
           // Skip notifications with unknown types or parsing errors
           debugPrint('Error parsing notification ${docSnapshot.id}: $e');
@@ -104,7 +104,8 @@ class NotificationsService {
     _numNotificationsViewedStreamController.add(aggregateQuery.count ?? 0);
   }
 
-  NotificationViewModel _convertToViewModel(Notification notification) {
+  Future<NotificationViewModel> _convertToViewModel(
+      Notification notification) async {
     if (notification is UnknownNotification) {
       return UnknownNotificationViewModel(
         notification: notification,
@@ -112,6 +113,41 @@ class NotificationsService {
       );
     }
 
-    throw 'No view model for notification type: ${notification.runtimeType}';
+    if (notification is TeamInviteNotification) {
+      final inviter = await _playerCache.retrievePlayer(notification.inviterId);
+      return TeamInviteNotificationViewModel(
+        notification: notification,
+        inviterName: inviter.name,
+      );
+    }
+
+    if (notification is TeamInviteAcceptedNotification) {
+      final invitee = await _playerCache.retrievePlayer(notification.inviteeId);
+      return TeamInviteAcceptedNotificationViewModel(
+        notification: notification,
+        inviteeName: invitee.name,
+      );
+    }
+
+    if (notification is TeamRemovedNotification) {
+      return TeamRemovedNotificationViewModel(
+        notification: notification,
+      );
+    }
+
+    if (notification is TeamCaptaincyReceivedNotification) {
+      final previousCaptain =
+          await _playerCache.retrievePlayer(notification.previousCaptainId);
+      return TeamCaptaincyReceivedNotificationViewModel(
+        notification: notification,
+        previousCaptainName: previousCaptain.name,
+      );
+    }
+
+    // Fallback for any unhandled types
+    return UnknownNotificationViewModel(
+      notification: notification as UnknownNotification,
+      type: 'unknown',
+    );
   }
 }

--- a/lib/notifications/notificatons_screen.dart
+++ b/lib/notifications/notificatons_screen.dart
@@ -1,5 +1,7 @@
+import 'package:crowdleague/teams/teams_service.dart';
 import 'package:crowdleague/utils/locator.dart';
 import 'package:flutter/material.dart' hide Notification;
+import 'package:go_router/go_router.dart';
 
 import 'notifications_service.dart';
 import 'models/views/notification_view_model.dart';
@@ -49,18 +51,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
                         viewed: true);
                   }
 
-                  // For now, show a simple card for unknown/legacy notifications
-                  if (viewModel is UnknownNotificationViewModel) {
-                    return Card(
-                      child: ListTile(
-                        leading: const Icon(Icons.notifications),
-                        title: Text('Notification'),
-                        subtitle: Text('Type: ${viewModel.type}'),
-                      ),
-                    );
-                  }
-
-                  return Container();
+                  return _buildNotificationCard(context, viewModel);
                 },
               );
             }
@@ -70,5 +61,140 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
         ),
       ),
     );
+  }
+
+  Widget _buildNotificationCard(
+      BuildContext context, NotificationViewModel viewModel) {
+    // Team invite notification
+    if (viewModel is TeamInviteNotificationViewModel) {
+      return Card(
+        child: ListTile(
+          leading: CircleAvatar(
+            backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+            child: Icon(
+              Icons.groups,
+              color: Theme.of(context).colorScheme.onPrimaryContainer,
+            ),
+          ),
+          title: Text('Team Invite: ${viewModel.teamInvite.teamName}'),
+          subtitle: Text('${viewModel.inviterName} invited you to join'),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.check, color: Colors.green),
+                onPressed: () => _acceptTeamInvite(viewModel),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, color: Colors.red),
+                onPressed: () => _declineTeamInvite(viewModel),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Team invite accepted notification
+    if (viewModel is TeamInviteAcceptedNotificationViewModel) {
+      return Card(
+        child: ListTile(
+          leading: CircleAvatar(
+            backgroundColor: Colors.green,
+            child: const Icon(Icons.check, color: Colors.white),
+          ),
+          title: Text('${viewModel.inviteeName} joined your team'),
+          subtitle: Text(viewModel.teamInviteAccepted.teamName),
+          onTap: () => context.pushNamed(
+            'team-detail',
+            pathParameters: {'id': viewModel.teamInviteAccepted.teamId},
+          ),
+        ),
+      );
+    }
+
+    // Team removed notification
+    if (viewModel is TeamRemovedNotificationViewModel) {
+      return Card(
+        child: ListTile(
+          leading: CircleAvatar(
+            backgroundColor: Colors.orange,
+            child: const Icon(Icons.exit_to_app, color: Colors.white),
+          ),
+          title: const Text('Removed from team'),
+          subtitle:
+              Text('You were removed from ${viewModel.teamRemoved.teamName}'),
+        ),
+      );
+    }
+
+    // Team captaincy received notification
+    if (viewModel is TeamCaptaincyReceivedNotificationViewModel) {
+      return Card(
+        child: ListTile(
+          leading: CircleAvatar(
+            backgroundColor: Colors.amber,
+            child: const Icon(Icons.star, color: Colors.white),
+          ),
+          title: Text(
+              'You are now captain of ${viewModel.captaincyReceived.teamName}'),
+          subtitle: Text(
+              '${viewModel.previousCaptainName} transferred captaincy to you'),
+          onTap: () => context.pushNamed(
+            'team-detail',
+            pathParameters: {'id': viewModel.captaincyReceived.teamId},
+          ),
+        ),
+      );
+    }
+
+    // Unknown/legacy notification
+    if (viewModel is UnknownNotificationViewModel) {
+      return Card(
+        child: ListTile(
+          leading: const Icon(Icons.notifications),
+          title: const Text('Notification'),
+          subtitle: Text('Type: ${viewModel.type}'),
+        ),
+      );
+    }
+
+    return Container();
+  }
+
+  Future<void> _acceptTeamInvite(
+      TeamInviteNotificationViewModel viewModel) async {
+    try {
+      await locate<TeamsService>().acceptInvite(viewModel.teamInvite.inviteId);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Joined ${viewModel.teamInvite.teamName}')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to accept invite: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _declineTeamInvite(
+      TeamInviteNotificationViewModel viewModel) async {
+    try {
+      await locate<TeamsService>().declineInvite(viewModel.teamInvite.inviteId);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Invite declined')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to decline invite: $e')),
+        );
+      }
+    }
   }
 }

--- a/lib/players/models/player.dart
+++ b/lib/players/models/player.dart
@@ -6,12 +6,14 @@ class Player {
   final String name;
   final int picId;
   final List<String> venueCrewIds;
+  final List<String> teamIds;
 
   const Player({
     required this.id,
     required this.name,
     required this.picId,
     required this.venueCrewIds,
+    required this.teamIds,
   });
 
   Map<String, dynamic> toJson() {
@@ -20,6 +22,7 @@ class Player {
       'name': name,
       'picId': picId,
       'venueCrewIds': venueCrewIds,
+      'teamIds': teamIds,
     };
   }
 
@@ -31,12 +34,14 @@ class Player {
       venueCrewIds: (json['venueCrewIds'] == null)
           ? []
           : List<String>.from(json['venueCrewIds']),
+      teamIds:
+          (json['teamIds'] == null) ? [] : List<String>.from(json['teamIds']),
     );
   }
 
   @override
   String toString() {
-    return 'Player{id: $id, name: $name, picId: $picId, venueCrewIds: $venueCrewIds}';
+    return 'Player{id: $id, name: $name, picId: $picId, venueCrewIds: $venueCrewIds, teamIds: $teamIds}';
   }
 
   String constructProfilePicUrl(PicSize picSize) {
@@ -58,5 +63,6 @@ class EmptyPlayer extends Player {
     super.name = '?',
     super.picId = 0,
     super.venueCrewIds = const [],
+    super.teamIds = const [],
   });
 }

--- a/lib/players/player_profile_screen.dart
+++ b/lib/players/player_profile_screen.dart
@@ -1,6 +1,8 @@
 import 'package:crowdleague/players/enums/pic_size.dart';
 import 'package:crowdleague/conversations/conversations_service.dart';
 import 'package:crowdleague/services/user_service.dart';
+import 'package:crowdleague/teams/models/team.dart';
+import 'package:crowdleague/teams/teams_service.dart';
 import 'package:crowdleague/venues/venues_service.dart';
 import 'package:crowdleague/venues/models/venue.dart';
 import 'package:flutter/material.dart';
@@ -26,6 +28,8 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
   bool _findingConversation = false;
   List<Venue> _venueCrews = [];
   bool _loadingVenues = true;
+  List<Team> _teams = [];
+  bool _loadingTeams = true;
 
   @override
   void initState() {
@@ -61,6 +65,33 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
     }
   }
 
+  Future<void> _loadTeams(List<String> teamIds) async {
+    if (teamIds.isEmpty) {
+      if (mounted) {
+        setState(() {
+          _teams = [];
+          _loadingTeams = false;
+        });
+      }
+      return;
+    }
+
+    final teams = <Team>[];
+    for (final teamId in teamIds) {
+      final team = await locate<TeamsService>().getTeam(teamId);
+      if (team != null) {
+        teams.add(team);
+      }
+    }
+
+    if (mounted) {
+      setState(() {
+        _teams = teams;
+        _loadingTeams = false;
+      });
+    }
+  }
+
   Future<void> _openConversation() async {
     setState(() {
       _findingConversation = true;
@@ -88,6 +119,11 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
             // Load venue crews when player data changes
             if (snapshot.hasData && _loadingVenues) {
               _loadVenueCrews(player.venueCrewIds);
+            }
+
+            // Load teams when player data changes
+            if (snapshot.hasData && _loadingTeams) {
+              _loadTeams(player.teamIds);
             }
 
             // Bust the cache so changes like `picStatus` will show up
@@ -191,6 +227,84 @@ class _PlayerProfileScreenState extends State<PlayerProfileScreen> {
                                   '${venue.crewMemberIds.length} ${venue.crewMemberIds.length == 1 ? 'member' : 'members'}'),
                               onTap: () =>
                                   context.push('/venue-detail/${venue.id}'),
+                            )),
+                      // Teams section
+                      Padding(
+                        padding: const EdgeInsets.only(
+                            left: 8.0, top: 20, bottom: 10),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.groups, size: 20),
+                            const SizedBox(width: 8),
+                            Text(
+                              'Teams',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const Spacer(),
+                            if (_owner)
+                              TextButton(
+                                onPressed: () => context.pushNamed('teams'),
+                                child: const Text('View All'),
+                              ),
+                          ],
+                        ),
+                      ),
+                      if (_loadingTeams)
+                        const Padding(
+                          padding: EdgeInsets.all(16.0),
+                          child: Center(child: CircularProgressIndicator()),
+                        )
+                      else if (_teams.isEmpty)
+                        Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                _owner
+                                    ? 'You haven\'t joined any teams yet'
+                                    : 'Not a member of any teams',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(color: Colors.grey),
+                              ),
+                              if (_owner) ...[
+                                const SizedBox(height: 12),
+                                OutlinedButton.icon(
+                                  onPressed: () =>
+                                      context.pushNamed('create-team'),
+                                  icon: const Icon(Icons.add),
+                                  label: const Text('Create a Team'),
+                                ),
+                              ],
+                            ],
+                          ),
+                        )
+                      else
+                        ..._teams.map((team) => ListTile(
+                              leading: CircleAvatar(
+                                backgroundColor: Theme.of(context)
+                                    .colorScheme
+                                    .primaryContainer,
+                                child: Text(
+                                  team.name.isNotEmpty
+                                      ? team.name[0].toUpperCase()
+                                      : 'T',
+                                  style: TextStyle(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onPrimaryContainer,
+                                  ),
+                                ),
+                              ),
+                              title: Text(team.name),
+                              subtitle: Text(
+                                  '${team.memberIds.length} ${team.memberIds.length == 1 ? 'member' : 'members'}'),
+                              onTap: () => context.pushNamed(
+                                'team-detail',
+                                pathParameters: {'id': team.id},
+                              ),
                             )),
                     ],
                   ),

--- a/lib/teams/models/team.dart
+++ b/lib/teams/models/team.dart
@@ -1,0 +1,55 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Team {
+  final String id;
+  final String name;
+  final String captainId;
+  final List<String> memberIds;
+  final int? logoId;
+  final DateTime createdAt;
+
+  static const int maxRosterSize = 15;
+
+  const Team({
+    required this.id,
+    required this.name,
+    required this.captainId,
+    required this.memberIds,
+    required this.createdAt,
+    this.logoId,
+  });
+
+  factory Team.fromJsonWithId(String id, Map<String, dynamic> json) {
+    return Team(
+      id: id,
+      name: json['name'] ?? '',
+      captainId: json['captainId'] ?? '',
+      memberIds: (json['memberIds'] == null)
+          ? []
+          : List<String>.from(json['memberIds']),
+      logoId: json['logoId'],
+      createdAt: json['createdAt'] is Timestamp
+          ? (json['createdAt'] as Timestamp).toDate()
+          : DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'captainId': captainId,
+      'memberIds': memberIds,
+      'logoId': logoId,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+
+  bool get isFull => memberIds.length >= maxRosterSize;
+
+  int get memberCount => memberIds.length;
+
+  @override
+  String toString() {
+    return 'Team{id: $id, name: $name, captainId: $captainId, memberIds: $memberIds}';
+  }
+}

--- a/lib/teams/models/team_invite.dart
+++ b/lib/teams/models/team_invite.dart
@@ -1,0 +1,56 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum TeamInviteStatus { pending, accepted, declined }
+
+class TeamInvite {
+  final String id;
+  final String teamId;
+  final String teamName;
+  final String inviterId;
+  final String inviteeId;
+  final TeamInviteStatus status;
+  final DateTime createdAt;
+
+  const TeamInvite({
+    required this.id,
+    required this.teamId,
+    required this.teamName,
+    required this.inviterId,
+    required this.inviteeId,
+    required this.status,
+    required this.createdAt,
+  });
+
+  factory TeamInvite.fromJsonWithId(String id, Map<String, dynamic> json) {
+    return TeamInvite(
+      id: id,
+      teamId: json['teamId'] ?? '',
+      teamName: json['teamName'] ?? '',
+      inviterId: json['inviterId'] ?? '',
+      inviteeId: json['inviteeId'] ?? '',
+      status: TeamInviteStatus.values.firstWhere(
+        (e) => e.name == json['status'],
+        orElse: () => TeamInviteStatus.pending,
+      ),
+      createdAt: json['createdAt'] is Timestamp
+          ? (json['createdAt'] as Timestamp).toDate()
+          : DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'teamId': teamId,
+      'teamName': teamName,
+      'inviterId': inviterId,
+      'inviteeId': inviteeId,
+      'status': status.name,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+
+  @override
+  String toString() {
+    return 'TeamInvite{id: $id, teamId: $teamId, inviteeId: $inviteeId, status: $status}';
+  }
+}

--- a/lib/teams/screens/create_team_screen.dart
+++ b/lib/teams/screens/create_team_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../utils/locator.dart';
+import '../teams_service.dart';
+
+class CreateTeamScreen extends StatefulWidget {
+  const CreateTeamScreen({super.key});
+
+  @override
+  State<CreateTeamScreen> createState() => _CreateTeamScreenState();
+}
+
+class _CreateTeamScreenState extends State<CreateTeamScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _createTeam() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      final teamId = await locate<TeamsService>().createTeam(
+        _nameController.text.trim(),
+      );
+      if (mounted) {
+        context.goNamed('team-detail', pathParameters: {'id': teamId});
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create team: $e')),
+        );
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Team'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: 'Team Name',
+                  hintText: 'Enter your team name',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a team name';
+                  }
+                  if (value.trim().length < 3) {
+                    return 'Team name must be at least 3 characters';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _createTeam,
+                child: _isLoading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create Team'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/teams/screens/invite_to_team_screen.dart
+++ b/lib/teams/screens/invite_to_team_screen.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../players/enums/pic_size.dart';
+import '../../players/models/player.dart';
+import '../../players/players_service.dart';
+import '../../services/user_service.dart';
+import '../../utils/locator.dart';
+import '../../utils/widgets/avatar.dart';
+import '../models/team.dart';
+import '../teams_service.dart';
+
+class InviteToTeamScreen extends StatefulWidget {
+  final String teamId;
+
+  const InviteToTeamScreen({super.key, required this.teamId});
+
+  @override
+  State<InviteToTeamScreen> createState() => _InviteToTeamScreenState();
+}
+
+class _InviteToTeamScreenState extends State<InviteToTeamScreen> {
+  final _searchController = TextEditingController();
+  List<Player>? _allPlayers;
+  List<Player>? _filteredPlayers;
+  Team? _team;
+  bool _isLoading = true;
+  final Set<String> _invitingPlayerIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadData() async {
+    setState(() => _isLoading = true);
+    try {
+      final team = await locate<TeamsService>().getTeam(widget.teamId);
+      final players = await locate<PlayersService>().retrievePlayers();
+
+      // Filter out current user and existing team members
+      final currentUserId = locate<UserService>().currentUserId;
+      final eligiblePlayers = players.where((p) {
+        if (p.id == currentUserId) return false;
+        if (team != null && team.memberIds.contains(p.id)) return false;
+        return true;
+      }).toList();
+
+      if (mounted) {
+        setState(() {
+          _team = team;
+          _allPlayers = eligiblePlayers;
+          _filteredPlayers = eligiblePlayers;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isLoading = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to load players: $e')),
+        );
+      }
+    }
+  }
+
+  void _filterPlayers(String query) {
+    if (_allPlayers == null) return;
+
+    setState(() {
+      if (query.isEmpty) {
+        _filteredPlayers = _allPlayers;
+      } else {
+        _filteredPlayers = _allPlayers!
+            .where((p) => p.name.toLowerCase().contains(query.toLowerCase()))
+            .toList();
+      }
+    });
+  }
+
+  Future<void> _invitePlayer(Player player) async {
+    if (_team == null) return;
+
+    // Check roster limit
+    if (_team!.memberIds.length >= Team.maxRosterSize) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Team roster is full')),
+      );
+      return;
+    }
+
+    setState(() => _invitingPlayerIds.add(player.id));
+
+    try {
+      await locate<TeamsService>().inviteToTeam(widget.teamId, player.id);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Invited ${player.name}')),
+        );
+        // Remove invited player from list
+        setState(() {
+          _allPlayers?.removeWhere((p) => p.id == player.id);
+          _filteredPlayers?.removeWhere((p) => p.id == player.id);
+          _invitingPlayerIds.remove(player.id);
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _invitingPlayerIds.remove(player.id));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to invite: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Invite Players'),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: TextField(
+                    controller: _searchController,
+                    decoration: const InputDecoration(
+                      hintText: 'Search by name',
+                      prefixIcon: Icon(Icons.search),
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: _filterPlayers,
+                  ),
+                ),
+                if (_team != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Text(
+                      'Team: ${_team!.name} '
+                      '(${_team!.memberIds.length}/${Team.maxRosterSize})',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: _filteredPlayers == null || _filteredPlayers!.isEmpty
+                      ? Center(
+                          child: Text(
+                            _searchController.text.isEmpty
+                                ? 'No players available to invite'
+                                : 'No players found',
+                            style: TextStyle(color: Colors.grey[600]),
+                          ),
+                        )
+                      : ListView.builder(
+                          itemCount: _filteredPlayers!.length,
+                          itemBuilder: (context, index) {
+                            final player = _filteredPlayers![index];
+                            final isInviting =
+                                _invitingPlayerIds.contains(player.id);
+
+                            return Card(
+                              margin: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 4,
+                              ),
+                              child: ListTile(
+                                onTap: () => context.pushNamed(
+                                  'player-profile',
+                                  pathParameters: {'id': player.id},
+                                ),
+                                leading: Avatar(
+                                  playerId: player.id,
+                                  picSize: PicSize.small,
+                                  size: 40,
+                                ),
+                                title: Text(player.name),
+                                trailing: isInviting
+                                    ? const SizedBox(
+                                        width: 24,
+                                        height: 24,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                        ),
+                                      )
+                                    : IconButton(
+                                        icon: const Icon(Icons.person_add),
+                                        onPressed: () => _invitePlayer(player),
+                                      ),
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/teams/screens/team_detail_screen.dart
+++ b/lib/teams/screens/team_detail_screen.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../players/enums/pic_size.dart';
+import '../../players/models/player.dart';
+import '../../utils/locator.dart';
+import '../../utils/widgets/avatar.dart';
+import '../models/team.dart';
+import '../teams_service.dart';
+
+class TeamDetailScreen extends StatefulWidget {
+  final String teamId;
+
+  const TeamDetailScreen({super.key, required this.teamId});
+
+  @override
+  State<TeamDetailScreen> createState() => _TeamDetailScreenState();
+}
+
+class _TeamDetailScreenState extends State<TeamDetailScreen> {
+  Team? _team;
+  List<Player>? _members;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTeam();
+  }
+
+  Future<void> _loadTeam() async {
+    setState(() => _isLoading = true);
+    try {
+      final team = await locate<TeamsService>().getTeam(widget.teamId);
+      List<Player>? members;
+      if (team != null) {
+        members = await locate<TeamsService>().getTeamMembers(widget.teamId);
+      }
+      if (mounted) {
+        setState(() {
+          _team = team;
+          _members = members;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isLoading = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to load team: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _leaveTeam() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Leave Team'),
+        content: const Text('Are you sure you want to leave this team?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Leave'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await locate<TeamsService>().leaveTeam(widget.teamId);
+      if (mounted) {
+        context.pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to leave team: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _deleteTeam() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Team'),
+        content: const Text(
+          'Are you sure you want to delete this team? '
+          'This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await locate<TeamsService>().deleteTeam(widget.teamId);
+      if (mounted) {
+        context.pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to delete team: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_team == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: Text('Team not found')),
+      );
+    }
+
+    final team = _team!;
+    final isCaptain = locate<TeamsService>().isCaptain(team);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(team.name),
+        actions: [
+          if (isCaptain)
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                switch (value) {
+                  case 'invite':
+                    context.pushNamed(
+                      'invite-to-team',
+                      pathParameters: {'id': widget.teamId},
+                    );
+                    break;
+                  case 'delete':
+                    _deleteTeam();
+                    break;
+                }
+              },
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 'invite',
+                  child: ListTile(
+                    leading: Icon(Icons.person_add),
+                    title: Text('Invite Player'),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+                const PopupMenuItem(
+                  value: 'delete',
+                  child: ListTile(
+                    leading: Icon(Icons.delete, color: Colors.red),
+                    title: Text('Delete Team',
+                        style: TextStyle(color: Colors.red)),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _loadTeam,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Team info card
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: [
+                    CircleAvatar(
+                      radius: 40,
+                      backgroundColor:
+                          Theme.of(context).colorScheme.primaryContainer,
+                      child: Text(
+                        team.name.isNotEmpty ? team.name[0].toUpperCase() : 'T',
+                        style: TextStyle(
+                          color:
+                              Theme.of(context).colorScheme.onPrimaryContainer,
+                          fontSize: 32,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      team.name,
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${team.memberIds.length} / ${Team.maxRosterSize} members',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Members section
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Members',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                if (isCaptain)
+                  TextButton.icon(
+                    onPressed: () => context.pushNamed(
+                      'invite-to-team',
+                      pathParameters: {'id': widget.teamId},
+                    ),
+                    icon: const Icon(Icons.person_add, size: 18),
+                    label: const Text('Invite'),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            if (_members != null)
+              ...(_members!.map((player) => Card(
+                    child: ListTile(
+                      onTap: () => context.pushNamed(
+                        'player-profile',
+                        pathParameters: {'id': player.id},
+                      ),
+                      leading: Avatar(
+                        playerId: player.id,
+                        picSize: PicSize.small,
+                        size: 40,
+                      ),
+                      title: Text(player.name),
+                      subtitle: player.id == team.captainId
+                          ? const Text('Captain',
+                              style: TextStyle(color: Colors.orange))
+                          : null,
+                      trailing: isCaptain && player.id != team.captainId
+                          ? PopupMenuButton<String>(
+                              onSelected: (value) async {
+                                if (value == 'remove') {
+                                  final confirmed = await showDialog<bool>(
+                                    context: context,
+                                    builder: (context) => AlertDialog(
+                                      title: const Text('Remove Member'),
+                                      content: Text(
+                                        'Remove ${player.name} from the team?',
+                                      ),
+                                      actions: [
+                                        TextButton(
+                                          onPressed: () =>
+                                              Navigator.pop(context, false),
+                                          child: const Text('Cancel'),
+                                        ),
+                                        TextButton(
+                                          onPressed: () =>
+                                              Navigator.pop(context, true),
+                                          child: const Text('Remove'),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                                  if (confirmed == true) {
+                                    try {
+                                      await locate<TeamsService>().removeMember(
+                                        widget.teamId,
+                                        player.id,
+                                      );
+                                      _loadTeam();
+                                    } catch (e) {
+                                      if (mounted) {
+                                        ScaffoldMessenger.of(context)
+                                            .showSnackBar(
+                                          SnackBar(
+                                            content:
+                                                Text('Failed to remove: $e'),
+                                          ),
+                                        );
+                                      }
+                                    }
+                                  }
+                                } else if (value == 'transfer') {
+                                  final confirmed = await showDialog<bool>(
+                                    context: context,
+                                    builder: (context) => AlertDialog(
+                                      title: const Text('Transfer Captaincy'),
+                                      content: Text(
+                                        'Make ${player.name} the captain?',
+                                      ),
+                                      actions: [
+                                        TextButton(
+                                          onPressed: () =>
+                                              Navigator.pop(context, false),
+                                          child: const Text('Cancel'),
+                                        ),
+                                        TextButton(
+                                          onPressed: () =>
+                                              Navigator.pop(context, true),
+                                          child: const Text('Transfer'),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                                  if (confirmed == true) {
+                                    try {
+                                      await locate<TeamsService>()
+                                          .transferCaptaincy(
+                                        widget.teamId,
+                                        player.id,
+                                      );
+                                      _loadTeam();
+                                    } catch (e) {
+                                      if (mounted) {
+                                        ScaffoldMessenger.of(context)
+                                            .showSnackBar(
+                                          SnackBar(
+                                            content:
+                                                Text('Failed to transfer: $e'),
+                                          ),
+                                        );
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              itemBuilder: (context) => [
+                                const PopupMenuItem(
+                                  value: 'transfer',
+                                  child: Text('Make Captain'),
+                                ),
+                                const PopupMenuItem(
+                                  value: 'remove',
+                                  child: Text('Remove'),
+                                ),
+                              ],
+                            )
+                          : null,
+                    ),
+                  ))),
+
+            const SizedBox(height: 24),
+
+            // Leave team button (for non-captains)
+            if (!isCaptain)
+              OutlinedButton(
+                onPressed: _leaveTeam,
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.red,
+                  side: const BorderSide(color: Colors.red),
+                ),
+                child: const Text('Leave Team'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/teams/screens/teams_list_screen.dart
+++ b/lib/teams/screens/teams_list_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../utils/locator.dart';
+import '../models/team.dart';
+import '../teams_service.dart';
+
+class TeamsListScreen extends StatefulWidget {
+  const TeamsListScreen({super.key});
+
+  @override
+  State<TeamsListScreen> createState() => _TeamsListScreenState();
+}
+
+class _TeamsListScreenState extends State<TeamsListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Teams'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => context.pushNamed('create-team'),
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<Team>>(
+        future: locate<TeamsService>().getUserTeams(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasData && snapshot.data!.isNotEmpty) {
+            final teams = snapshot.data!;
+            return ListView.builder(
+              itemCount: teams.length,
+              itemBuilder: (context, index) {
+                final team = teams[index];
+                return Card(
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  child: ListTile(
+                    onTap: () => context.pushNamed(
+                      'team-detail',
+                      pathParameters: {'id': team.id},
+                    ),
+                    leading: CircleAvatar(
+                      backgroundColor:
+                          Theme.of(context).colorScheme.primaryContainer,
+                      child: Text(
+                        team.name.isNotEmpty ? team.name[0].toUpperCase() : 'T',
+                        style: TextStyle(
+                          color:
+                              Theme.of(context).colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                    ),
+                    title: Text(team.name),
+                    subtitle: Text('${team.memberIds.length} members'),
+                    trailing: const Icon(Icons.chevron_right),
+                  ),
+                );
+              },
+            );
+          } else {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.groups_outlined,
+                    size: 64,
+                    color: Colors.grey[400],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No teams yet',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Create a team or get invited to one',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[500],
+                        ),
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton.icon(
+                    onPressed: () => context.pushNamed('create-team'),
+                    icon: const Icon(Icons.add),
+                    label: const Text('Create Team'),
+                  ),
+                ],
+              ),
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/teams/teams_service.dart
+++ b/lib/teams/teams_service.dart
@@ -1,0 +1,184 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../players/models/player.dart';
+import '../utils/globals.dart';
+import 'models/team.dart';
+import 'models/team_invite.dart';
+
+class TeamsService {
+  TeamsService({
+    required FirebaseFirestore firestore,
+    required FirebaseAuth auth,
+    required FirebaseFunctions cloudFunctions,
+  })  : _firestore = firestore,
+        _auth = auth,
+        _cloudFunctions = cloudFunctions;
+
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+  final FirebaseFunctions _cloudFunctions;
+
+  /// Create a new team with the current user as captain
+  Future<String> createTeam(String name) async {
+    final result = await _cloudFunctions.httpsCallable('createTeam').call({
+      'teamName': name,
+      'dbName': kDatabaseName,
+    });
+    return result.data['teamId'];
+  }
+
+  /// Get a team by ID
+  Future<Team?> getTeam(String teamId) async {
+    final doc = await _firestore.collection('teams').doc(teamId).get();
+    if (!doc.exists || doc.data() == null) return null;
+    return Team.fromJsonWithId(doc.id, doc.data()!);
+  }
+
+  /// Stream team updates for real-time UI
+  Stream<Team?> teamStream(String teamId) {
+    return _firestore.collection('teams').doc(teamId).snapshots().map(
+        (doc) => doc.exists ? Team.fromJsonWithId(doc.id, doc.data()!) : null);
+  }
+
+  /// Get all teams the current user belongs to
+  Future<List<Team>> getUserTeams() async {
+    final userId = _auth.currentUser?.uid;
+    if (userId == null) return [];
+
+    final snapshot = await _firestore
+        .collection('teams')
+        .where('memberIds', arrayContains: userId)
+        .get();
+
+    return snapshot.docs
+        .map((doc) => Team.fromJsonWithId(doc.id, doc.data()))
+        .toList();
+  }
+
+  /// Get the members of a team as Player objects
+  Future<List<Player>> getTeamMembers(String teamId) async {
+    final team = await getTeam(teamId);
+    if (team == null) return [];
+
+    final players = <Player>[];
+    for (final memberId in team.memberIds) {
+      final doc = await _firestore.collection('profiles').doc(memberId).get();
+      if (doc.exists && doc.data() != null) {
+        players.add(Player.fromJsonWithId(memberId, doc.data()!));
+      }
+    }
+    return players;
+  }
+
+  /// Invite a player to a team (captain only)
+  Future<void> inviteToTeam(String teamId, String playerId) async {
+    await _cloudFunctions.httpsCallable('inviteToTeam').call({
+      'teamId': teamId,
+      'inviteeId': playerId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Accept a team invite
+  Future<void> acceptInvite(String inviteId) async {
+    await _cloudFunctions.httpsCallable('acceptTeamInvite').call({
+      'inviteId': inviteId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Decline a team invite
+  Future<void> declineInvite(String inviteId) async {
+    await _cloudFunctions.httpsCallable('declineTeamInvite').call({
+      'inviteId': inviteId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Leave a team (non-captain members only)
+  Future<void> leaveTeam(String teamId) async {
+    await _cloudFunctions.httpsCallable('leaveTeam').call({
+      'teamId': teamId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Remove a member from a team (captain only)
+  Future<void> removeMember(String teamId, String playerId) async {
+    await _cloudFunctions.httpsCallable('removeFromTeam').call({
+      'teamId': teamId,
+      'playerId': playerId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Transfer captaincy to another member
+  Future<void> transferCaptaincy(String teamId, String newCaptainId) async {
+    await _cloudFunctions.httpsCallable('transferCaptaincy').call({
+      'teamId': teamId,
+      'newCaptainId': newCaptainId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Delete a team (captain only)
+  Future<void> deleteTeam(String teamId) async {
+    await _cloudFunctions.httpsCallable('deleteTeam').call({
+      'teamId': teamId,
+      'dbName': kDatabaseName,
+    });
+  }
+
+  /// Check if the current user is the captain of a team
+  bool isCaptain(Team team) {
+    return team.captainId == _auth.currentUser?.uid;
+  }
+
+  /// Check if the current user is a member of a team
+  bool isMember(Team team) {
+    final userId = _auth.currentUser?.uid;
+    if (userId == null) return false;
+    return team.memberIds.contains(userId);
+  }
+
+  /// Get pending team invites for the current user
+  Future<List<TeamInvite>> getPendingInvites() async {
+    final userId = _auth.currentUser?.uid;
+    if (userId == null) return [];
+
+    final snapshot = await _firestore
+        .collection('teamInvites')
+        .where('inviteeId', isEqualTo: userId)
+        .where('status', isEqualTo: 'pending')
+        .orderBy('createdAt', descending: true)
+        .get();
+
+    return snapshot.docs
+        .map((doc) => TeamInvite.fromJsonWithId(doc.id, doc.data()))
+        .toList();
+  }
+
+  /// Get pending invites sent by the current user for a specific team
+  Future<List<TeamInvite>> getTeamPendingInvites(String teamId) async {
+    final snapshot = await _firestore
+        .collection('teamInvites')
+        .where('teamId', isEqualTo: teamId)
+        .where('status', isEqualTo: 'pending')
+        .get();
+
+    return snapshot.docs
+        .map((doc) => TeamInvite.fromJsonWithId(doc.id, doc.data()))
+        .toList();
+  }
+
+  /// Update team details (captain only) - name for now
+  Future<void> updateTeam(String teamId, {String? name}) async {
+    final updates = <String, dynamic>{};
+    if (name != null) updates['name'] = name;
+    if (updates.isNotEmpty) {
+      await _firestore.collection('teams').doc(teamId).update(updates);
+    }
+  }
+}

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -47,6 +47,7 @@ void main() {
         name: 'John Doe',
         picId: 123,
         venueCrewIds: ['venue1'],
+        teamIds: ['team1'],
       );
 
       final json = player.toJson();
@@ -55,6 +56,7 @@ void main() {
       expect(json['name'], 'John Doe');
       expect(json['picId'], 123);
       expect(json['venueCrewIds'], ['venue1']);
+      expect(json['teamIds'], ['team1']);
     });
 
     test('toString returns formatted string', () {
@@ -63,6 +65,7 @@ void main() {
         name: 'John Doe',
         picId: 123,
         venueCrewIds: ['venue1'],
+        teamIds: [],
       );
 
       expect(player.toString(), contains('player123'));
@@ -75,6 +78,7 @@ void main() {
         name: 'John',
         picId: 456,
         venueCrewIds: [],
+        teamIds: [],
       );
 
       final url = player.constructProfilePicUrl(PicSize.small);
@@ -89,6 +93,7 @@ void main() {
         name: 'John',
         picId: 456,
         venueCrewIds: [],
+        teamIds: [],
       );
 
       final url = player.constructProfilePicUrl(PicSize.medium);
@@ -102,6 +107,7 @@ void main() {
         name: 'John',
         picId: 456,
         venueCrewIds: [],
+        teamIds: [],
       );
 
       final url = player.constructProfilePicUrl(PicSize.large);

--- a/test/user_feedback_bugs_test.dart
+++ b/test/user_feedback_bugs_test.dart
@@ -107,18 +107,21 @@ void main() {
           name: 'Alice Johnson',
           picId: 0,
           venueCrewIds: [],
+          teamIds: [],
         ));
         mockPlayersService.addPlayer(const Player(
           id: 'player-bob',
           name: 'Bob Smith',
           picId: 0,
           venueCrewIds: [],
+          teamIds: [],
         ));
         mockPlayersService.addPlayer(const Player(
           id: 'player-charlie',
           name: 'Charlie Brown',
           picId: 0,
           venueCrewIds: [],
+          teamIds: [],
         ));
 
         // Add test conversations


### PR DESCRIPTION
## Summary
Implements the Basic Teams feature allowing players to create and manage teams.

## Features
- **Create teams** with max 15 member roster
- **Invite players** to team (captain only)
- **Accept/decline** team invites from notifications screen
- **Leave team** or remove members (captain can remove)
- **Transfer captaincy** to another team member
- **Delete team** (captain only)

## New Files
### Models
- `lib/teams/models/team.dart` - Team model
- `lib/teams/models/team_invite.dart` - TeamInvite model

### Service
- `lib/teams/teams_service.dart` - Full service layer

### UI Screens
- `teams_list_screen.dart` - List user's teams
- `create_team_screen.dart` - Create new team
- `team_detail_screen.dart` - Team info and member management
- `invite_to_team_screen.dart` - Search and invite players

### Cloud Functions (8 new)
- `createTeam`, `inviteToTeam`, `acceptTeamInvite`, `declineTeamInvite`
- `leaveTeam`, `removeFromTeam`, `transferCaptaincy`, `deleteTeam`

## Updates to Existing Files
- **Player model**: Added `teamIds` field
- **Player profile screen**: Shows teams section with "View All" link
- **Notifications**: Added team invite types with accept/decline buttons
- **Firestore rules**: Added rules for `teams` and `teamInvites` collections
- **main.dart**: Registered TeamsService and team routes
- **Tests**: Updated to include `teamIds` field

## Bug Fix
- Fixed white-on-pink contrast issue using Material 3 `primaryContainer`/`onPrimaryContainer` colors

## Testing
- ✅ Flutter analyze: 0 errors
- ✅ Flutter tests: 110 passed
- ✅ Functions lint: 0 errors  
- ✅ Functions tests: 83 passed