### PR TITLE
Bump version to 0.0.13+27 for release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: crowdleague
 description: "Be in a league of your own..."
 publish_to: "none"
 
-version: 0.0.12+26
+version: 0.0.13+27
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Version bump for Teams feature release (Phase 2A)

## Changes
- Version: 0.0.12+26 → 0.0.13+27

## Release includes
- Teams feature (PR #295)